### PR TITLE
Prefix RPC env vars with ENVIO_

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,17 @@
 # To create or update a token visit https://envio.dev/app/api-tokens
 ENVIO_API_TOKEN="<YOUR-API-TOKEN>"
+
+# RPC URLs for each supported chain. Set these to override the
+# defaults provided by Envio.
+ENVIO_MAINNET_RPC_URL=""
+ENVIO_ARBITRUM_RPC_URL=""
+ENVIO_OPTIMISM_RPC_URL=""
+ENVIO_BASE_RPC_URL=""
+ENVIO_POLYGON_RPC_URL=""
+ENVIO_AVALANCHE_RPC_URL=""
+ENVIO_BSC_RPC_URL=""
+ENVIO_BLAST_RPC_URL=""
+ENVIO_ZORA_RPC_URL=""
+ENVIO_SONIEUM_RPC_URL=""
+ENVIO_UNICHAIN_RPC_URL=""
+ENVIO_INK_RPC_URL=""

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ http://localhost:8080
 
 This will open the Hasura console where you can explore and query the indexed data using GraphQL.
 
+### RPC Configuration
+
+RPC endpoints for each chain can be customized through environment variables prefixed with `ENVIO_`.
+For example:
+
+```
+ENVIO_MAINNET_RPC_URL=https://your-mainnet-node
+ENVIO_ARBITRUM_RPC_URL=https://your-arbitrum-node
+```
+
+See `.env.example` for the complete list of variables you can set.
+
 ## Usage
 
 You can use this indexer to power your own Uniswap v4 applications and infrastructure. The indexed data is accessible via GraphQL API.

--- a/src/utils/tokenMetadata.ts
+++ b/src/utils/tokenMetadata.ts
@@ -65,29 +65,29 @@ interface TokenMetadata {
 const getRpcUrl = (chainId: number): string => {
   switch (chainId) {
     case 1:
-      return process.env.MAINNET_RPC_URL || "https://eth.drpc.org";
+      return process.env.ENVIO_MAINNET_RPC_URL || "https://eth.drpc.org";
     case 42161:
-      return process.env.ARBITRUM_RPC_URL || "https://arbitrum.drpc.org";
+      return process.env.ENVIO_ARBITRUM_RPC_URL || "https://arbitrum.drpc.org";
     case 10:
-      return process.env.OPTIMISM_RPC_URL || "https://optimism.drpc.org";
+      return process.env.ENVIO_OPTIMISM_RPC_URL || "https://optimism.drpc.org";
     case 8453:
-      return process.env.BASE_RPC_URL || "https://base.drpc.org";
+      return process.env.ENVIO_BASE_RPC_URL || "https://base.drpc.org";
     case 137:
-      return process.env.POLYGON_RPC_URL || "https://polygon.drpc.org";
+      return process.env.ENVIO_POLYGON_RPC_URL || "https://polygon.drpc.org";
     case 43114:
-      return process.env.AVALANCHE_RPC_URL || "https://avalanche.drpc.org";
+      return process.env.ENVIO_AVALANCHE_RPC_URL || "https://avalanche.drpc.org";
     case 56:
-      return process.env.BSC_RPC_URL || "https://bsc.drpc.org";
+      return process.env.ENVIO_BSC_RPC_URL || "https://bsc.drpc.org";
     case 81457:
-      return process.env.BLAST_RPC_URL || "https://blast.drpc.org";
+      return process.env.ENVIO_BLAST_RPC_URL || "https://blast.drpc.org";
     case 7777777:
-      return process.env.ZORA_RPC_URL || "https://zora.drpc.org";
+      return process.env.ENVIO_ZORA_RPC_URL || "https://zora.drpc.org";
     case 1868:
-      return process.env.SONIEUM_RPC_URL || "https://sonieum.drpc.org";
+      return process.env.ENVIO_SONIEUM_RPC_URL || "https://sonieum.drpc.org";
     case 130:
-      return process.env.UNICHAIN_RPC_URL || "https://unichain.drpc.org";
+      return process.env.ENVIO_UNICHAIN_RPC_URL || "https://unichain.drpc.org";
     case 57073:
-      return process.env.INK_RPC_URL || "https://ink.drpc.org";
+      return process.env.ENVIO_INK_RPC_URL || "https://ink.drpc.org";
     // Add generic fallback for any chain
     default:
       throw new Error(`No RPC URL configured for chainId ${chainId}`);


### PR DESCRIPTION
## Summary
- update environment variable names in `tokenMetadata` to use `ENVIO_` prefix
- add RPC URL examples to `.env.example`
- document how to override RPC URLs in README

## Testing
- `pnpm test` *(fails: ts-mocha not found)*