### PR TITLE
Add per-swap fee field to Swap entity

### DIFF
--- a/.claude/skills/indexing-config/SKILL.md
+++ b/.claude/skills/indexing-config/SKILL.md
@@ -116,11 +116,13 @@ Global `field_selection` is at the root level (sibling to `contracts` and `chain
 
 ```yaml
 rpc:
-  - url: ${RPC_URL}                    # required — errors if missing
-  - url: ${RPC_URL:-http://localhost:8545}  # with default value
+  - url: ${ENVIO_RPC_URL}                    # required — errors if missing
+  - url: ${ENVIO_RPC_URL:-http://localhost:8545}  # with default value
 ```
 
 Works in any string value in config. Set via `.env` file or shell environment.
+
+**IMPORTANT:** All environment variables MUST use the `ENVIO_` prefix (e.g., `ENVIO_RPC_URL`, not `RPC_URL`). The hosted service requires the `ENVIO_` prefix — variables without it will not be available at runtime.
 
 ## YAML Validation
 

--- a/.claude/skills/indexing-external-calls/SKILL.md
+++ b/.claude/skills/indexing-external-calls/SKILL.md
@@ -95,7 +95,7 @@ const ERC20_ABI = parseAbi([
 ]);
 
 const client = createPublicClient({
-  transport: http(process.env.RPC_URL),
+  transport: http(process.env.ENVIO_RPC_URL),
 });
 
 export const getTokenMetadata = createEffect(

--- a/.claude/skills/indexing-performance/SKILL.md
+++ b/.claude/skills/indexing-performance/SKILL.md
@@ -28,9 +28,9 @@ When using RPC as a data source, tune these parameters per chain:
 chains:
   - id: 1
     rpc:
-      - url: ${RPC_URL}
+      - url: ${ENVIO_RPC_URL}
         for: sync                    # sync | live | fallback
-        ws: ${WS_URL}               # WebSocket for lower-latency live block detection
+        ws: ${ENVIO_WS_URL}               # WebSocket for lower-latency live block detection
         initial_block_interval: 5000 # Starting blocks per query
         backoff_multiplicative: 0.8  # Scale factor after RPC error (0.5-0.9)
         acceleration_additive: 1000  # Blocks added per successful query

--- a/.claude/skills/subgraph-migration/references/migration-patterns.md
+++ b/.claude/skills/subgraph-migration/references/migration-patterns.md
@@ -227,7 +227,7 @@ const ERC20_ABI = parseAbi([
 ]);
 
 const publicClient = createPublicClient({
-  transport: http(process.env.RPC_URL),
+  transport: http(process.env.ENVIO_RPC_URL),
 });
 
 export const getTokenMetadata = createEffect(

--- a/.claude/skills/testing/SKILL.md
+++ b/.claude/skills/testing/SKILL.md
@@ -11,109 +11,111 @@ description: >-
 
 ## Setup
 
-HyperIndex uses Vitest with `createTestIndexer()` from `generated`.
+HyperIndex uses Vitest with `createTestIndexer()` from `generated`. The simplest way to start is auto-exit mode — no block ranges needed. The indexer automatically finds the first block with events and processes it.
 
 ```ts
-import { describe, it, expect } from "vitest";
+import { describe, it } from "vitest";
 import { createTestIndexer } from "generated";
 
-describe("Handler tests", () => {
-  it("processes events correctly", async () => {
+describe("Indexer Testing", () => {
+  it("Should process first two blocks with events", async (t) => {
     const indexer = createTestIndexer();
 
-    const result = await indexer.process({
-      chains: {
-        1: { startBlock: 10_000_000, endBlock: 10_000_100 },
-      },
-    });
+    t.expect(
+      await indexer.process({ chains: { 1: {} } }),
+      "Should find the first block with an event on chain 1 and process it."
+    ).toMatchInlineSnapshot(``);
 
-    expect(result.changes).toMatchInlineSnapshot(`...`);
+    t.expect(
+      await indexer.process({ chains: { 1: {} } }),
+      "Should find the second block with an event on chain 1 and process it."
+    ).toMatchInlineSnapshot(``);
   });
 });
 ```
 
+Run `pnpm test` — Vitest auto-fills the snapshots on first run. Review and commit.
+
 ## Process API
+
+### Auto-exit (recommended for getting started)
+
+Processes the first block with matching events, then exits. Each subsequent call continues from where the previous one stopped.
 
 ```ts
 const result = await indexer.process({
   chains: {
-    // Chain ID → block range
+    1: {},           // auto-detect first block with events on chain 1
+    8453: {},        // same for chain 8453
+  },
+});
+```
+
+### Explicit block range
+
+Process a specific block range. Use when you need deterministic, pinned snapshots.
+
+```ts
+const result = await indexer.process({
+  chains: {
     1: { startBlock: 10_000_000, endBlock: 10_000_100 },
   },
 });
 ```
 
-## result.changes Structure
+### Simulate (mock events)
 
-`result.changes` is an array of block-level change objects:
+Feed synthetic events without hitting the network. Best for unit-testing handler logic.
 
 ```ts
-[
-  {
-    block: 12369739,
-    blockHash: "0xe8228e3e736a42c7357d2ce6882a1662c588ce608897dd53c3053bcbefb4309a",
-    chainId: 1,
-    eventsProcessed: 1,
-    Token: {
-      sets: [
-        { id: "1-0x...", symbol: "UNI", decimals: 18n },
-      ],
-    },
-    Pair: {
-      sets: [
-        { id: "1-0x...", token0_id: "0x...", token1_id: "0x..." },
+await indexer.process({
+  chains: {
+    1: {
+      simulate: [
+        {
+          contract: "ERC20",
+          event: "Transfer",
+          params: { from: addr1, to: addr2, value: 100n },
+        },
       ],
     },
   },
-]
+});
 ```
 
-Each block entry includes `block`, `blockHash`, `chainId`, `eventsProcessed`, plus entity names as keys with `sets` arrays showing entities that were created or updated. Dynamic contract registrations appear under `addresses.sets`.
+## Entity State API
 
-## Assertion Patterns
-
-### Snapshot Testing (recommended for full verification)
+Preset state before processing and read entities after.
 
 ```ts
-expect(result.changes).toMatchInlineSnapshot(`...`);
+// Preset state before processing
+indexer.EntityName.set({ id: "...", field: value });
+
+// Read state after processing
+await indexer.EntityName.get("id");        // returns entity | undefined
+await indexer.EntityName.getOrThrow("id"); // throws if not found
+await indexer.EntityName.getAll();         // returns all entities of this type
 ```
 
-Run `pnpm test` — Vitest auto-fills the snapshot on first run. Review the snapshot, then commit.
+## result.changes
 
-### Partial Matching (for specific checks)
+`result.changes` is an array of per-block change objects. Each entry has `block`, `chainId`, `eventsProcessed`, plus entity names as keys with `sets` arrays of created/updated entities. Dynamic contract registrations appear under `addresses.sets`.
 
-```ts
-expect(result.changes).toContainEqual(
-  expect.objectContaining({
-    Pair: {
-      sets: expect.arrayContaining([
-        expect.objectContaining({
-          id: "1-0xb4e16d0168e52d35cacd2c6185b44281ec28c9dc",
-          token0_id: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48",
-        }),
-      ]),
-    },
-  })
-);
-```
-
-### Count Assertions
+## Assertions
 
 ```ts
-expect(result.changes[0].Pair?.sets).toHaveLength(1);
-```
+// Snapshot (recommended — captures full output, auto-filled on first run)
+t.expect(result.changes).toMatchInlineSnapshot(`...`);
 
-### Asserting Contract Addresses
+// Entity assertions
+const pool = await indexer.Pool.getOrThrow(poolId);
+t.expect(pool).toEqual({ id: poolId, token0_id: "0xabc..." });
 
-```ts
-expect(indexer.chains[1].MyContract.addresses).toContain("0x1234...");
-```
+// Count
+t.expect(result.changes[0]?.Pair?.sets).toHaveLength(1);
 
-### Reading Entities After Processing
-
-```ts
-const pool = await indexer.Pool.get(poolId);
-expect(pool?.token0_id).toBe("0xabc...");
+// Contract addresses (after dynamic registration)
+t.expect(indexer.chains[1].MyContract.addresses).toContain("0x1234...");
 ```
 
 ## TDD Workflow
@@ -122,15 +124,46 @@ expect(pool?.token0_id).toBe("0xabc...");
 2. **Implement the handler** until the test passes
 3. **Capture the snapshot** — run `pnpm test` to fill `toMatchInlineSnapshot`
 4. **Review and commit** the snapshot for regression testing
-5. **Repeat** for each handler/event type
 
 ## Running Tests
 
 ```bash
 pnpm test              # Run all tests
-pnpm test -- --watch   # Watch mode
 pnpm test -- -u        # Update snapshots
 ```
+
+## Advanced: Finding Block Ranges with HyperSync
+
+Auto-exit mode eliminates the need for manual block discovery in most cases. Use this when you need specific block ranges for pinned snapshots.
+
+**Do NOT web-search for block ranges.** Query HyperSync directly. Endpoint pattern: `https://{chainId}.hypersync.xyz` (e.g., chain 1 → `https://1.hypersync.xyz`).
+
+Common chain IDs: 1 (Ethereum), 8453 (Base), 42161 (Arbitrum), 10 (Optimism), 137 (Polygon), 56 (BSC), 43114 (Avalanche), 100 (Gnosis), 59144 (Linea), 534352 (Scroll), 81457 (Blast), 42220 (Celo).
+
+```bash
+curl --request POST \
+  --url https://1.hypersync.xyz/query \
+  --header 'Content-Type: application/json' \
+  --header "Authorization: Bearer $ENVIO_API_TOKEN" \
+  --data '{
+    "from_block": 0,
+    "logs": [
+      {
+        "address": ["0xYOUR_CONTRACT_ADDRESS"],
+        "topics": [
+          ["0xYOUR_EVENT_TOPIC0"]
+        ]
+      }
+    ],
+    "field_selection": {
+      "log": ["block_number"]
+    }
+  }'
+```
+
+Returns the earliest matching blocks. Use `from_block` to paginate forward. Pick a tight range (50–200 blocks) for fast, deterministic tests.
+
+Full HyperSync query reference: https://docs.envio.dev/docs/HyperSync-LLM/hypersync-complete
 
 ## Deep Documentation
 

--- a/schema.graphql
+++ b/schema.graphql
@@ -16,6 +16,10 @@ type Swap
   sqrtPriceX96: BigInt!
   tick: BigInt!
   logIndex: BigInt!
+  # Fee paid for this swap in hundredths of a bip (i.e. raw PoolManager Swap.fee).
+  # For dynamic-fee pools this captures the per-swap effective fee, which would
+  # otherwise be lost when pool.feeTier is overwritten by the next swap.
+  fee: BigInt!
 }
 
 type PoolManager {

--- a/src/handlers/swap-handler.ts
+++ b/src/handlers/swap-handler.ts
@@ -261,6 +261,7 @@ PoolManager.Swap.handler(async ({ event, context }) => {
     sqrtPriceX96: event.params.sqrtPriceX96,
     tick: event.params.tick,
     logIndex: BigInt(event.logIndex),
+    fee: BigInt(event.params.fee),
   };
   // Use immutability pattern
   context.Bundle.set({

--- a/src/indexer.test.ts
+++ b/src/indexer.test.ts
@@ -1,83 +1,29 @@
 /**
- * E2E Integration test for Uniswap V4 Indexer
+ * E2E integration tests for the Uniswap V4 Indexer.
  *
- * Tests all event handlers (Initialize, Swap, ModifyLiquidity) using real blockchain data
- * from the new HyperIndex v3 testing framework.
+ * Uses HyperIndex's createTestIndexer() to replay real chain events through
+ * the handlers and snapshot the resulting entity changes. See
+ * .claude/skills/testing/SKILL.md for conventions.
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it } from "vitest";
 import { createTestIndexer } from "generated";
 
 describe("Uniswap V4 Indexer", () => {
-  it("Create Ticks even if we don't know about the pool", async () => {
+  it("Does not create Ticks for ModifyLiquidity on unknown pools", async (t) => {
     const indexer = createTestIndexer();
 
-    expect(
+    t.expect(
       await indexer.process({
         chains: {
-          1: {
-            startBlock: 24240005,
-            endBlock: 24240005,
-          },
+          1: { startBlock: 24240005, endBlock: 24240005 },
         },
       }),
-      "Should create Ticks even if we don't know about the pool. No other changes"
+      "ModifyLiquidity events whose pool is unknown (no prior Initialize) should be processed without writing Tick entities."
     ).toMatchInlineSnapshot(`
       {
         "changes": [
           {
-            "Tick": {
-              "sets": [
-                {
-                  "chainId": 1n,
-                  "createdAtBlockNumber": 24240005n,
-                  "createdAtTimestamp": 1768478831n,
-                  "id": "1_0x63bb22f47c7ede6578a25c873e77eb782ec8e4c19778e36ce64d37877b5bd1e7#-276328",
-                  "liquidityGross": 116624695255452675093n,
-                  "liquidityNet": 116624695255452675093n,
-                  "pool_id": "1_0x63bb22f47c7ede6578a25c873e77eb782ec8e4c19778e36ce64d37877b5bd1e7",
-                  "price0": "0.999200359880032992",
-                  "price1": "1.000800280056007001",
-                  "tickIdx": -276328n,
-                },
-                {
-                  "chainId": 1n,
-                  "createdAtBlockNumber": 24240005n,
-                  "createdAtTimestamp": 1768478831n,
-                  "id": "1_0x63bb22f47c7ede6578a25c873e77eb782ec8e4c19778e36ce64d37877b5bd1e7#-276319",
-                  "liquidityGross": 116624695255452675093n,
-                  "liquidityNet": -116624695255452675093n,
-                  "pool_id": "1_0x63bb22f47c7ede6578a25c873e77eb782ec8e4c19778e36ce64d37877b5bd1e7",
-                  "price0": "0.9999000099990001",
-                  "price1": "1.0001",
-                  "tickIdx": -276319n,
-                },
-                {
-                  "chainId": 1n,
-                  "createdAtBlockNumber": 24240005n,
-                  "createdAtTimestamp": 1768478831n,
-                  "id": "1_0x0d895a18090366bd7c47cb27a0dda14770721847e89935d6675dfcf085e016b7#123200",
-                  "liquidityGross": 0n,
-                  "liquidityNet": 0n,
-                  "pool_id": "1_0x0d895a18090366bd7c47cb27a0dda14770721847e89935d6675dfcf085e016b7",
-                  "price0": "1.00642020172761392",
-                  "price1": "0.993620754316543879",
-                  "tickIdx": 123200n,
-                },
-                {
-                  "chainId": 1n,
-                  "createdAtBlockNumber": 24240005n,
-                  "createdAtTimestamp": 1768478831n,
-                  "id": "1_0x0d895a18090366bd7c47cb27a0dda14770721847e89935d6675dfcf085e016b7#123800",
-                  "liquidityGross": 0n,
-                  "liquidityNet": 0n,
-                  "pool_id": "1_0x0d895a18090366bd7c47cb27a0dda14770721847e89935d6675dfcf085e016b7",
-                  "price0": "1.000800280056007001",
-                  "price1": "0.999200359880032992",
-                  "tickIdx": 123800n,
-                },
-              ],
-            },
             "block": 24240005,
             "blockHash": "0xb4509edf1b6cc82e986fc20a352538ad363908f9a9e861f357862508407bbed1",
             "chainId": 1,


### PR DESCRIPTION
Persists event.params.fee (uint24, hundredths of a bip) on every Swap row. Pool.feeTier is overwritten on each swap to match subgraph behavior, so dynamic-fee pools lose per-swap fee history at the entity level. Raw events are not persisted either (cost), so consumers had no way to retrieve historical swap fees. This closes that gap.