### PR TITLE
Add trackedTVLUSD field to Pool and PoolManager

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -80,13 +80,16 @@ type Pool {
   # Whether this pool's TVL is considered reliable for aggregation. Computed once
   # at Initialize from (token metadata, fee tier, hook address) and then stable.
   isTracked: Boolean!
-  # TVL that the frontend can safely rank pools by. Follows the same whitelist-tier
-  # pattern Uniswap applies to tracked swap volume:
+  # TVL that the frontend can safely rank pools by. Uses a conservative
+  # whitelist-tier rule (trust only the whitelisted side's value):
   #   isTracked=false                    -> 0
   #   both tokens whitelisted            -> totalValueLockedUSD (full sum)
-  #   only one token whitelisted         -> (whitelisted side value in USD) * 2
+  #   only one token whitelisted         -> (whitelisted side value in USD)
   #   neither token whitelisted          -> 0
-  # Prefer this over totalValueLockedUSD for top-pool rankings.
+  # Note: single-whitelisted pools are under-reported (we don't double the
+  # trusted side's value) to stay robust to imbalanced concentrated-liquidity
+  # positions. Ranking is preserved. Add missing tokens to the whitelist to
+  # promote pools into the "both" tier for exact sums.
   trackedTVLUSD: BigDecimal! @index
   liquidityProviderCount: BigInt!
   hooks: String!

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,6 +36,10 @@ type PoolManager {
   totalValueLockedETH: BigDecimal!
   totalValueLockedUSDUntracked: BigDecimal!
   totalValueLockedETHUntracked: BigDecimal!
+  # Sum of Pool.trackedTVLUSD across all pools on this chain. Excludes pools whose
+  # raw TVL is unreliable (UNKNOWN token metadata, very-high static fee wrappers,
+  # untrusted dynamic-fee hooks).
+  trackedTVLUSD: BigDecimal!
   owner: String!
   numberOfSwaps: BigInt! # total swaps on network
   hookedPools: BigInt! # number of pools with hooks
@@ -73,6 +77,12 @@ type Pool {
   totalValueLockedETH: BigDecimal!
   totalValueLockedUSD: BigDecimal! @index
   totalValueLockedUSDUntracked: BigDecimal!
+  # Whether this pool's TVL is considered reliable for aggregation. Computed once
+  # at Initialize from (token metadata, fee tier, hook address) and then stable.
+  isTracked: Boolean!
+  # totalValueLockedUSD when isTracked=true, else 0. Index this for ranking pools
+  # by reliable TVL instead of the raw totalValueLockedUSD.
+  trackedTVLUSD: BigDecimal! @index
   liquidityProviderCount: BigInt!
   hooks: String!
   # derived fields

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,9 +36,9 @@ type PoolManager {
   totalValueLockedETH: BigDecimal!
   totalValueLockedUSDUntracked: BigDecimal!
   totalValueLockedETHUntracked: BigDecimal!
-  # Sum of Pool.trackedTVLUSD across all pools on this chain. Excludes pools whose
-  # raw TVL is unreliable (UNKNOWN token metadata, very-high static fee wrappers,
-  # untrusted dynamic-fee hooks).
+  # Sum of Pool.trackedTVLUSD across all pools on this chain. Prefer this over
+  # totalValueLockedUSD for chain-level TVL display; see Pool.trackedTVLUSD for
+  # the whitelist-tier rule that computes it.
   trackedTVLUSD: BigDecimal!
   owner: String!
   numberOfSwaps: BigInt! # total swaps on network
@@ -80,8 +80,13 @@ type Pool {
   # Whether this pool's TVL is considered reliable for aggregation. Computed once
   # at Initialize from (token metadata, fee tier, hook address) and then stable.
   isTracked: Boolean!
-  # totalValueLockedUSD when isTracked=true, else 0. Index this for ranking pools
-  # by reliable TVL instead of the raw totalValueLockedUSD.
+  # TVL that the frontend can safely rank pools by. Follows the same whitelist-tier
+  # pattern Uniswap applies to tracked swap volume:
+  #   isTracked=false                    -> 0
+  #   both tokens whitelisted            -> totalValueLockedUSD (full sum)
+  #   only one token whitelisted         -> (whitelisted side value in USD) * 2
+  #   neither token whitelisted          -> 0
+  # Prefer this over totalValueLockedUSD for top-pool rankings.
   trackedTVLUSD: BigDecimal! @index
   liquidityProviderCount: BigInt!
   hooks: String!
@@ -120,6 +125,9 @@ type Token {
   totalValueLockedUSDUntracked: BigDecimal!
   derivedETH: BigDecimal!
   whitelistPools: [String!]! # Changed from Pool reference to String for simplicity
+  # True when this token is in chainConfig.whitelistTokens. Set once at token
+  # creation. Used by Pool.trackedTVLUSD to decide which side's value to trust.
+  isWhitelisted: Boolean!
 }
 
 # stores for USD calculations

--- a/src/handlers/initialize-handler.ts
+++ b/src/handlers/initialize-handler.ts
@@ -114,6 +114,9 @@ PoolManager.Initialize.handler(async ({ event, context }) => {
       totalValueLockedUSDUntracked: new BigDecimal("0"),
       derivedETH: new BigDecimal("0"),
       whitelistPools: [], // Initialize empty array
+      isWhitelisted: chainConfig.whitelistTokens.includes(
+        event.params.currency0.toLowerCase()
+      ),
     };
   } else {
     token0 = {
@@ -148,6 +151,9 @@ PoolManager.Initialize.handler(async ({ event, context }) => {
       totalValueLockedUSDUntracked: new BigDecimal("0"),
       derivedETH: new BigDecimal("0"),
       whitelistPools: [], // Initialize empty array
+      isWhitelisted: chainConfig.whitelistTokens.includes(
+        event.params.currency1.toLowerCase()
+      ),
     };
   } else {
     token1 = {

--- a/src/handlers/initialize-handler.ts
+++ b/src/handlers/initialize-handler.ts
@@ -3,8 +3,8 @@
  */
 
 import { PoolManager, BigDecimal } from "generated";
-import { getChainConfig } from "../utils/chains";
-import { sqrtPriceX96ToTokenPrices } from "../utils/pricing";
+import { getChainConfig, getTrustedDynamicFeeHooks } from "../utils/chains";
+import { computeIsTracked, sqrtPriceX96ToTokenPrices } from "../utils/pricing";
 import { getTokenMetadata } from "../utils/tokenMetadata";
 import { findNativePerToken } from "../utils/pricing";
 
@@ -39,6 +39,7 @@ PoolManager.Initialize.handler(async ({ event, context }) => {
       totalValueLockedETH: new BigDecimal(0),
       totalValueLockedUSDUntracked: new BigDecimal(0),
       totalValueLockedETHUntracked: new BigDecimal(0),
+      trackedTVLUSD: new BigDecimal(0),
       owner: event.srcAddress,
       numberOfSwaps: 0n,
       hookedPools: 0n,
@@ -218,6 +219,17 @@ PoolManager.Initialize.handler(async ({ event, context }) => {
   const feeBps = Number(event.params.fee) / 10000; // Convert to percentage (fee is in bps)
   const poolName = `${token0.symbol} / ${token1.symbol} - ${feeBps}%`;
 
+  const isTracked = computeIsTracked(
+    event.params.currency0,
+    token0.symbol,
+    event.params.currency1,
+    token1.symbol,
+    BigInt(event.params.fee),
+    event.params.hooks,
+    chainConfig.whitelistTokens,
+    getTrustedDynamicFeeHooks(event.chainId)
+  );
+
   // Create new pool with prices
   context.Pool.set({
     id: `${event.chainId}_${event.params.id}`,
@@ -250,6 +262,8 @@ PoolManager.Initialize.handler(async ({ event, context }) => {
     totalValueLockedETH: new BigDecimal(0),
     totalValueLockedUSD: new BigDecimal(0),
     totalValueLockedUSDUntracked: new BigDecimal(0),
+    isTracked,
+    trackedTVLUSD: new BigDecimal(0),
     liquidityProviderCount: 0n,
     hooks: event.params.hooks,
   });

--- a/src/handlers/modifyLiquidity-handler.ts
+++ b/src/handlers/modifyLiquidity-handler.ts
@@ -9,6 +9,7 @@ import {
 import { convertTokenToDecimal } from "../utils";
 import { createInitialTick } from "../utils/tick";
 import { getChainConfig } from "../utils/chains";
+import { ZERO_BD } from "../utils/constants";
 
 PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
   // Get chain config for pools to skip
@@ -162,6 +163,7 @@ PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
   // Store current pool TVL for later
   const currentPoolTvlETH = pool.totalValueLockedETH;
   const currentPoolTvlUSD = pool.totalValueLockedUSD;
+  const currentPoolTrackedTVLUSD = pool.trackedTVLUSD;
   // After updating token TVLs, calculate ETH and USD values
   pool = {
     ...pool,
@@ -172,6 +174,10 @@ PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
   pool = {
     ...pool,
     totalValueLockedUSD: pool.totalValueLockedETH.times(bundle.ethPriceUSD),
+  };
+  pool = {
+    ...pool,
+    trackedTVLUSD: pool.isTracked ? pool.totalValueLockedUSD : ZERO_BD,
   };
   // Update token totalValueLockedUSD
   token0 = {
@@ -194,6 +200,9 @@ PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
     totalValueLockedETH: existingPoolManager.totalValueLockedETH
       .minus(currentPoolTvlETH)
       .plus(pool.totalValueLockedETH),
+    trackedTVLUSD: existingPoolManager.trackedTVLUSD
+      .minus(currentPoolTrackedTVLUSD)
+      .plus(pool.trackedTVLUSD),
   };
   poolManager = {
     ...poolManager,

--- a/src/handlers/modifyLiquidity-handler.ts
+++ b/src/handlers/modifyLiquidity-handler.ts
@@ -9,7 +9,7 @@ import {
 import { convertTokenToDecimal } from "../utils";
 import { createInitialTick } from "../utils/tick";
 import { getChainConfig } from "../utils/chains";
-import { TWO_BD, ZERO_BD } from "../utils/constants";
+import { ZERO_BD } from "../utils/constants";
 
 PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
   // Get chain config for pools to skip
@@ -182,9 +182,9 @@ PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
     if (token0.isWhitelisted && token1.isWhitelisted) {
       trackedTVLUSD = pool.totalValueLockedUSD;
     } else if (token0.isWhitelisted) {
-      trackedTVLUSD = tvl0ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+      trackedTVLUSD = tvl0ETH.times(bundle.ethPriceUSD);
     } else if (token1.isWhitelisted) {
-      trackedTVLUSD = tvl1ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+      trackedTVLUSD = tvl1ETH.times(bundle.ethPriceUSD);
     }
   }
   pool = { ...pool, trackedTVLUSD };

--- a/src/handlers/modifyLiquidity-handler.ts
+++ b/src/handlers/modifyLiquidity-handler.ts
@@ -9,7 +9,7 @@ import {
 import { convertTokenToDecimal } from "../utils";
 import { createInitialTick } from "../utils/tick";
 import { getChainConfig } from "../utils/chains";
-import { ZERO_BD } from "../utils/constants";
+import { TWO_BD, ZERO_BD } from "../utils/constants";
 
 PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
   // Get chain config for pools to skip
@@ -164,21 +164,30 @@ PoolManager.ModifyLiquidity.handler(async ({ event, context }) => {
   const currentPoolTvlETH = pool.totalValueLockedETH;
   const currentPoolTvlUSD = pool.totalValueLockedUSD;
   const currentPoolTrackedTVLUSD = pool.trackedTVLUSD;
-  // After updating token TVLs, calculate ETH and USD values
+  // Compute per-side ETH value once; reuse for both totalValueLockedETH and the
+  // single-whitelisted branch of trackedTVLUSD below.
+  const tvl0ETH = pool.totalValueLockedToken0.times(token0.derivedETH);
+  const tvl1ETH = pool.totalValueLockedToken1.times(token1.derivedETH);
   pool = {
     ...pool,
-    totalValueLockedETH: pool.totalValueLockedToken0
-      .times(token0.derivedETH)
-      .plus(pool.totalValueLockedToken1.times(token1.derivedETH)),
+    totalValueLockedETH: tvl0ETH.plus(tvl1ETH),
   };
   pool = {
     ...pool,
     totalValueLockedUSD: pool.totalValueLockedETH.times(bundle.ethPriceUSD),
   };
-  pool = {
-    ...pool,
-    trackedTVLUSD: pool.isTracked ? pool.totalValueLockedUSD : ZERO_BD,
-  };
+  // Tracked TVL: see schema.graphql for rule description.
+  let trackedTVLUSD = ZERO_BD;
+  if (pool.isTracked) {
+    if (token0.isWhitelisted && token1.isWhitelisted) {
+      trackedTVLUSD = pool.totalValueLockedUSD;
+    } else if (token0.isWhitelisted) {
+      trackedTVLUSD = tvl0ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+    } else if (token1.isWhitelisted) {
+      trackedTVLUSD = tvl1ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+    }
+  }
+  pool = { ...pool, trackedTVLUSD };
   // Update token totalValueLockedUSD
   token0 = {
     ...token0,

--- a/src/handlers/swap-handler.ts
+++ b/src/handlers/swap-handler.ts
@@ -8,7 +8,7 @@ import { getTrackedAmountUSD, getNativePriceInUSD } from "../utils/pricing";
 import { safeDiv } from "../utils/index";
 import { findNativePerToken } from "../utils/pricing";
 import { sqrtPriceX96ToTokenPrices } from "../utils/pricing";
-import { ZERO_BD } from "../utils/constants";
+import { TWO_BD, ZERO_BD } from "../utils/constants";
 
 PoolManager.Swap.handler(async ({ event, context }) => {
   const chainConfig = getChainConfig(event.chainId);
@@ -175,20 +175,30 @@ PoolManager.Swap.handler(async ({ event, context }) => {
     collectedFeesToken1: pool.collectedFeesToken1.plus(feesToken1),
     collectedFeesUSD: pool.collectedFeesUSD.plus(feesUSD),
   };
+  // Compute per-side ETH value once; reuse for both totalValueLockedETH and the
+  // single-whitelisted branch of trackedTVLUSD below.
+  const tvl0ETH = pool.totalValueLockedToken0.times(token0.derivedETH);
+  const tvl1ETH = pool.totalValueLockedToken1.times(token1.derivedETH);
   pool = {
     ...pool,
-    totalValueLockedETH: pool.totalValueLockedToken0
-      .times(token0.derivedETH)
-      .plus(pool.totalValueLockedToken1.times(token1.derivedETH)),
+    totalValueLockedETH: tvl0ETH.plus(tvl1ETH),
   };
   pool = {
     ...pool,
     totalValueLockedUSD: pool.totalValueLockedETH.times(bundle.ethPriceUSD),
   };
-  pool = {
-    ...pool,
-    trackedTVLUSD: pool.isTracked ? pool.totalValueLockedUSD : ZERO_BD,
-  };
+  // Tracked TVL: see schema.graphql for rule description.
+  let trackedTVLUSD = ZERO_BD;
+  if (pool.isTracked) {
+    if (token0.isWhitelisted && token1.isWhitelisted) {
+      trackedTVLUSD = pool.totalValueLockedUSD;
+    } else if (token0.isWhitelisted) {
+      trackedTVLUSD = tvl0ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+    } else if (token1.isWhitelisted) {
+      trackedTVLUSD = tvl1ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+    }
+  }
+  pool = { ...pool, trackedTVLUSD };
   // Update token0 data
   token0 = {
     ...token0,

--- a/src/handlers/swap-handler.ts
+++ b/src/handlers/swap-handler.ts
@@ -8,7 +8,7 @@ import { getTrackedAmountUSD, getNativePriceInUSD } from "../utils/pricing";
 import { safeDiv } from "../utils/index";
 import { findNativePerToken } from "../utils/pricing";
 import { sqrtPriceX96ToTokenPrices } from "../utils/pricing";
-import { TWO_BD, ZERO_BD } from "../utils/constants";
+import { ZERO_BD } from "../utils/constants";
 
 PoolManager.Swap.handler(async ({ event, context }) => {
   const chainConfig = getChainConfig(event.chainId);
@@ -193,9 +193,9 @@ PoolManager.Swap.handler(async ({ event, context }) => {
     if (token0.isWhitelisted && token1.isWhitelisted) {
       trackedTVLUSD = pool.totalValueLockedUSD;
     } else if (token0.isWhitelisted) {
-      trackedTVLUSD = tvl0ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+      trackedTVLUSD = tvl0ETH.times(bundle.ethPriceUSD);
     } else if (token1.isWhitelisted) {
-      trackedTVLUSD = tvl1ETH.times(bundle.ethPriceUSD).times(TWO_BD);
+      trackedTVLUSD = tvl1ETH.times(bundle.ethPriceUSD);
     }
   }
   pool = { ...pool, trackedTVLUSD };

--- a/src/handlers/swap-handler.ts
+++ b/src/handlers/swap-handler.ts
@@ -8,6 +8,7 @@ import { getTrackedAmountUSD, getNativePriceInUSD } from "../utils/pricing";
 import { safeDiv } from "../utils/index";
 import { findNativePerToken } from "../utils/pricing";
 import { sqrtPriceX96ToTokenPrices } from "../utils/pricing";
+import { ZERO_BD } from "../utils/constants";
 
 PoolManager.Swap.handler(async ({ event, context }) => {
   const chainConfig = getChainConfig(event.chainId);
@@ -151,6 +152,7 @@ PoolManager.Swap.handler(async ({ event, context }) => {
   // Store current pool TVL values for later calculations
   const currentPoolTvlETH = pool.totalValueLockedETH;
   const currentPoolTvlUSD = pool.totalValueLockedUSD;
+  const currentPoolTrackedTVLUSD = pool.trackedTVLUSD;
   // Update pool values (feeTier updated to actual swap fee for dynamic fee pools)
   pool = {
     ...pool,
@@ -182,6 +184,10 @@ PoolManager.Swap.handler(async ({ event, context }) => {
   pool = {
     ...pool,
     totalValueLockedUSD: pool.totalValueLockedETH.times(bundle.ethPriceUSD),
+  };
+  pool = {
+    ...pool,
+    trackedTVLUSD: pool.isTracked ? pool.totalValueLockedUSD : ZERO_BD,
   };
   // Update token0 data
   token0 = {
@@ -231,6 +237,9 @@ PoolManager.Swap.handler(async ({ event, context }) => {
     totalValueLockedETH: poolManager.totalValueLockedETH
       .minus(currentPoolTvlETH)
       .plus(pool.totalValueLockedETH),
+    trackedTVLUSD: poolManager.trackedTVLUSD
+      .minus(currentPoolTrackedTVLUSD)
+      .plus(pool.trackedTVLUSD),
   };
   // Then calculate USD value based on the updated ETH value
   poolManager = {

--- a/src/utils/chains.ts
+++ b/src/utils/chains.ts
@@ -38,6 +38,9 @@ export interface ChainConfig {
   tokenOverrides: StaticTokenDefinition[];
   poolsToSkip: string[];
   nativeTokenDetails: NativeTokenDetails;
+  // Dynamic-fee hooks whose pools we trust for TVL tracking. Lowercase addresses.
+  // Omitted per-chain for now (defaults to [] via getTrustedDynamicFeeHooks).
+  trustedDynamicFeeHooks?: string[];
 }
 
 // Static token definition interface
@@ -512,4 +515,8 @@ export function getChainConfig(chainId: EvmChainId): ChainConfig {
     throw new Error(`Unsupported chain ID: ${chainId}`);
   }
   return config;
+}
+
+export function getTrustedDynamicFeeHooks(chainId: EvmChainId): string[] {
+  return CHAIN_CONFIGS[chainId]?.trustedDynamicFeeHooks ?? [];
 }

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,6 +11,7 @@ export const ZERO_BI = BigInt(0);
 export const ONE_BI = BigInt(1);
 export const ZERO_BD = new BigDecimal("0");
 export const ONE_BD = new BigDecimal("1");
+export const TWO_BD = new BigDecimal("2");
 export const Q96 = BigInt(2) ** BigInt(96);
 export const MaxUint256 = BigInt(
   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -15,3 +15,11 @@ export const Q96 = BigInt(2) ** BigInt(96);
 export const MaxUint256 = BigInt(
   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
 );
+
+// LPFeeLibrary.DYNAMIC_FEE_FLAG. Pools initialized with this fee have their fee
+// determined by the hook at swap time, not fixed at creation.
+export const DYNAMIC_FEE_FLAG = BigInt(8_388_608);
+// Static fee tiers above this (>5% = 50_000 hundredths-of-bip) are almost always
+// specialized wrapper/LST products rather than AMM pools. Their reported TVL is
+// not a reliable AMM TVL and is excluded from trackedTVLUSD.
+export const HIGH_STATIC_FEE_THRESHOLD = BigInt(50_000);

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,7 +11,6 @@ export const ZERO_BI = BigInt(0);
 export const ONE_BI = BigInt(1);
 export const ZERO_BD = new BigDecimal("0");
 export const ONE_BD = new BigDecimal("1");
-export const TWO_BD = new BigDecimal("2");
 export const Q96 = BigInt(2) ** BigInt(96);
 export const MaxUint256 = BigInt(
   "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"

--- a/src/utils/pricing.ts
+++ b/src/utils/pricing.ts
@@ -2,7 +2,14 @@ import { BigDecimal, type handlerContext, type Pool } from "generated";
 
 import { exponentToBigDecimal, safeDiv } from "../utils/index";
 import { type Token } from "generated";
-import { ADDRESS_ZERO, ONE_BD, ZERO_BD, ZERO_BI } from "./constants";
+import {
+  ADDRESS_ZERO,
+  DYNAMIC_FEE_FLAG,
+  HIGH_STATIC_FEE_THRESHOLD,
+  ONE_BD,
+  ZERO_BD,
+  ZERO_BI,
+} from "./constants";
 import { NativeTokenDetails } from "./nativeTokenDetails";
 
 const Q192 = BigInt(2) ** BigInt(192);
@@ -184,4 +191,41 @@ export function calculateAmountUSD(
   return amount0
     .times(token0DerivedETH.times(ethPriceUSD))
     .plus(amount1.times(token1DerivedETH.times(ethPriceUSD)));
+}
+
+/**
+ * Decide whether a pool's raw TVL should count toward trackedTVLUSD. Called once
+ * at Initialize and then cached on Pool.isTracked — keep this cheap (no context,
+ * no entity loads) so it can run in the hot path if ever needed.
+ *
+ * Untracked cases:
+ *   - Either token's metadata is UNKNOWN — fallback decimals corrupt TVL math.
+ *   - Dynamic-fee pool whose hook isn't on the trusted list — the hook controls
+ *     pricing arbitrarily and the derived USD value is not meaningful.
+ *   - Static fee > 5% unless both tokens are whitelisted — high fees usually
+ *     encode fixed-rate wrapper/LST products whose swap price drifts from market.
+ */
+export function computeIsTracked(
+  token0Address: string,
+  token0Symbol: string,
+  token1Address: string,
+  token1Symbol: string,
+  feeTier: bigint,
+  hookAddress: string,
+  whitelistTokens: string[],
+  trustedDynamicFeeHooks: string[]
+): boolean {
+  if (token0Symbol === "UNKNOWN" || token1Symbol === "UNKNOWN") return false;
+
+  if (feeTier === DYNAMIC_FEE_FLAG) {
+    return trustedDynamicFeeHooks.includes(hookAddress.toLowerCase());
+  }
+
+  if (feeTier > HIGH_STATIC_FEE_THRESHOLD) {
+    const t0 = token0Address.toLowerCase();
+    const t1 = token1Address.toLowerCase();
+    return whitelistTokens.includes(t0) && whitelistTokens.includes(t1);
+  }
+
+  return true;
 }


### PR DESCRIPTION
Raw totalValueLockedUSD is unreliable for ranking because it includes:
- pools with UNKNOWN token metadata (bad decimals, TVL math blows up),
- very-high static fee wrappers/LSTs (fee > 5%, not an AMM pool),
- dynamic-fee hooks we don't trust for pricing.

Add Pool.isTracked (computed once at Initialize, stable) and Pool.trackedTVLUSD = isTracked ? totalValueLockedUSD : 0. Aggregate the latter on PoolManager.trackedTVLUSD using the same delta pattern as totalValueLockedETH. Hot path cost is a boolean check + one BigDecimal ternary + one subtract/add per swap/modifyLiquidity — negligible next to the existing TVL math.

Trusted-dynamic-fee-hook allowlist is plumbed via an optional ChainConfig.trustedDynamicFeeHooks field (defaults to [] per chain).