### PR TITLE
chore: bump envio to 3.0.1 and enable ClickHouse storage

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,8 @@
 # yaml-language-server: $schema=./node_modules/envio/evm.schema.json
 name: uniswap-v4-indexer
+storage:
+  postgres: true
+  clickhouse: true
 contracts:
   - name: PoolManager
     events:

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "vitest": "4.1.0"
   },
   "dependencies": {
-    "envio": "3.0.0-rc.1"
+    "envio": "3.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.0.0-rc.1
-        version: 3.0.0-rc.1(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.0.1
+        version: 3.0.1(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -1010,8 +1010,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-arm64@3.0.0-rc.1:
-    resolution: {integrity: sha512-krDFIQLy6iYRoODg7QE4F/lBr3gssNcwZ7QIOrtcwogjNfnLS66xg6FuFH32xjOiBLWM84qzbfu/R+8Erix6mw==}
+  envio-darwin-arm64@3.0.1:
+    resolution: {integrity: sha512-BUeuyxP93WBm2kArF5Yxbr34KRyri2fH/HSrYecBEMBfgwR6Xccz72ZkpFMxcowQtt6yRwDcA+UpXrpjIhjI8A==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1020,8 +1020,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  envio-darwin-x64@3.0.0-rc.1:
-    resolution: {integrity: sha512-mpL34MtfHnvXnnC3JP8NEf26D8Rb76Gf3RkNOz/ULSgDF25uVo+v46uOpMR8cKcsTmf5N6u1yE+ee8jbVzFnVQ==}
+  envio-darwin-x64@3.0.1:
+    resolution: {integrity: sha512-eWN9K6JHvXlI32U0g1VKzsi+o4T+Dk87odJemHvtR27GkY/IZsHBP2ASD0BfFe5OVNwqvTtmPAsn/jakThx2TQ==}
     cpu: [x64]
     os: [darwin]
 
@@ -1030,13 +1030,13 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-arm64@3.0.0-rc.1:
-    resolution: {integrity: sha512-NRX7zyrHVTmx7Bugg8UM7lnycI47/twL1TtvvswnSnyJkmW7ozWhMqfP9JIRSi9m9cygx6ruxYDdPMS0aQxm7w==}
+  envio-linux-arm64@3.0.1:
+    resolution: {integrity: sha512-ZxxwZvgjyCE8+bQzordzOga8GJAVp87KbDfWBBFduSmyAiQf7Lsa8jMhAHj4A+AS4Hbmf7UmA/X44B/Q8f7waw==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64-musl@3.0.0-rc.1:
-    resolution: {integrity: sha512-Z7/2kqIQ/cWoKpNcjOHbWpHoXphKCO6NG2RI6aajVqm4A7FThvQ0QqlgEMJkOP3nBOhzUI2s6mWWg4e4g5OF6g==}
+  envio-linux-x64-musl@3.0.1:
+    resolution: {integrity: sha512-yyyRPouYms28Tvv9Yc1W/amjRdJMjRcMJb6cLPNRNKCSW5/V3AjewYWeTi+g3otZ6eVXEnFBeIjH2xf1rUxXiQ==}
     cpu: [x64]
     os: [linux]
 
@@ -1045,8 +1045,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  envio-linux-x64@3.0.0-rc.1:
-    resolution: {integrity: sha512-yd49rGWgjzDeXmaFQhMf/JZG6QaW4pJvpGeULQX+oZGR0Pc0Kj573FLaEHsWqT7nQyKC0YAuCQPDI5YYCaXUug==}
+  envio-linux-x64@3.0.1:
+    resolution: {integrity: sha512-wvyWnvy8bMw7kCdvtJqeM3a4jEA2kiIxDa2kCHOsJq2Aw5Z7kaW26OZ9BbWpRGvgtNVG0eiA8e0YvK1aDk+xIQ==}
     cpu: [x64]
     os: [linux]
 
@@ -1054,8 +1054,8 @@ packages:
     resolution: {integrity: sha512-xyo0mJc/+lAP0Og36Mdbn1m5xHXJXYjZ5E8s4eJQwjS3FFsEi8Z7lQc6qCHZjYtdRdGoGK2RLBMdEh5t+TRvrA==}
     hasBin: true
 
-  envio@3.0.0-rc.1:
-    resolution: {integrity: sha512-igKXgskxnaOsCxpjn5Y3tvIX6BcTG2p7PoVGoI1OXuiz1qkwwXqB8SmDXK2vM/PCzkz/Dq1IqgDOEODbnORjbw==}
+  envio@3.0.1:
+    resolution: {integrity: sha512-gEtvYCHM5i3XCRI+4g766SvSsExB4cY2qzSjbl2TSRWUEik5n7yHtcYCU52/LqPK4Inc9z2Dc0tHbuBCqZOYuQ==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2847,28 +2847,28 @@ snapshots:
   envio-darwin-arm64@2.24.0:
     optional: true
 
-  envio-darwin-arm64@3.0.0-rc.1:
+  envio-darwin-arm64@3.0.1:
     optional: true
 
   envio-darwin-x64@2.24.0:
     optional: true
 
-  envio-darwin-x64@3.0.0-rc.1:
+  envio-darwin-x64@3.0.1:
     optional: true
 
   envio-linux-arm64@2.24.0:
     optional: true
 
-  envio-linux-arm64@3.0.0-rc.1:
+  envio-linux-arm64@3.0.1:
     optional: true
 
-  envio-linux-x64-musl@3.0.0-rc.1:
+  envio-linux-x64-musl@3.0.1:
     optional: true
 
   envio-linux-x64@2.24.0:
     optional: true
 
-  envio-linux-x64@3.0.0-rc.1:
+  envio-linux-x64@3.0.1:
     optional: true
 
   envio@2.24.0(typescript@5.2.2):
@@ -2892,7 +2892,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  envio@3.0.0-rc.1(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3):
+  envio@3.0.1(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -2924,11 +2924,11 @@ snapshots:
       viem: 2.46.2(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.0.0-rc.1
-      envio-darwin-x64: 3.0.0-rc.1
-      envio-linux-arm64: 3.0.0-rc.1
-      envio-linux-x64: 3.0.0-rc.1
-      envio-linux-x64-musl: 3.0.0-rc.1
+      envio-darwin-arm64: 3.0.1
+      envio-darwin-x64: 3.0.1
+      envio-linux-arm64: 3.0.1
+      envio-linux-x64: 3.0.1
+      envio-linux-x64-musl: 3.0.1
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,4 +1,5 @@
 type Swap
+  @storage(postgres: true, clickhouse: true)
   @index(fields: ["timestamp", "pool"])
   @index(fields: ["amountUSD", "pool"]) {
   id: ID!
@@ -22,7 +23,7 @@ type Swap
   fee: BigInt!
 }
 
-type PoolManager {
+type PoolManager @storage(postgres: true, clickhouse: true) {
   id: ID!
   chainId: BigInt!
   poolCount: BigInt!
@@ -42,7 +43,7 @@ type PoolManager {
   hookedSwaps: BigInt! # number of swaps through hooked pools
 }
 
-type Pool {
+type Pool @storage(postgres: true, clickhouse: true) {
   id: ID!
   chainId: BigInt!
   name: String!
@@ -79,7 +80,7 @@ type Pool {
   ticks: [Tick!]! @derivedFrom(field: "pool")
 }
 
-type Tick {
+type Tick @storage(postgres: true, clickhouse: true) {
   id: ID! # <pool address>#<tickIdx>
   chainId: BigInt!
   pool: Pool! # Pointer back to Pool
@@ -92,7 +93,7 @@ type Tick {
   createdAtBlockNumber: BigInt!
 }
 
-type Token {
+type Token @storage(postgres: true, clickhouse: true) {
   id: ID!
   chainId: BigInt!
   symbol: String!
@@ -113,13 +114,13 @@ type Token {
 }
 
 # stores for USD calculations
-type Bundle {
+type Bundle @storage(postgres: true, clickhouse: true) {
   id: ID!
   # price of ETH in usd
   ethPriceUSD: BigDecimal!
 }
 
-type HookStats {
+type HookStats @storage(postgres: true, clickhouse: true) {
   id: ID! # hook address
   chainId: BigInt!
   numberOfPools: BigInt!
@@ -132,6 +133,7 @@ type HookStats {
 }
 
 type ModifyLiquidity
+  @storage(postgres: true, clickhouse: true)
   @index(fields: ["timestamp", "pool"])
   @index(fields: ["amountUSD", "pool"]) {
   id: ID!


### PR DESCRIPTION
Adds dual-storage configuration so every entity is written to both Postgres and ClickHouse via the @storage directive in schema.graphql.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated envio dependency to version 3.0.1.

* **Configuration**
  * Enabled PostgreSQL and ClickHouse storage backends for enhanced data persistence across core entity types including swaps, pools, tokens, and related data structures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/enviodev/uniswap-v4-indexer/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->