### PR TITLE
Upgrade envio dependency to 3.3.0-alpha.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "vitest": "4.1.0"
   },
   "dependencies": {
-    "envio": "3.2.0"
+    "envio": "3.3.0-alpha.10"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.2.0
-        version: 3.2.0(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.3.0-alpha.10
+        version: 3.3.0-alpha.10(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -111,6 +111,7 @@ packages:
 
   '@clickhouse/client-common@1.17.0':
     resolution: {integrity: sha512-MiwwgXViFAQA2YZkN4ymF1ynzG0K49KeSX9/iOcmJetWkxqSekDdpyp1GjwATWa9R215uQ+hGzJtJujeQVZZIw==}
+    deprecated: 'Deprecated: import from @clickhouse/client or @clickhouse/client-web instead.'
 
   '@clickhouse/client@1.17.0':
     resolution: {integrity: sha512-Y3DQoamKZ/Iyosoq7Lj7lqpDkQDK4R/5mI52yJs4ZLPIO+d6/CYDqTbFBIb4No3C/AlXUYE4TKhj/kXDpe6rOA==}
@@ -127,49 +128,6 @@ packages:
   '@elastic/ecs-pino-format@1.4.0':
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
-
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    resolution: {integrity: sha512-eQyd9kJCIz/4WCTjkjpQg80DA3pdneHP7qhJIVQ2ZG+Jew9o5XDG+uI0Y16AgGzZ6KGmJSJF6wyUaaAjJfbO1Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    resolution: {integrity: sha512-l7lRMSoyIiIvKZgQPfgqg7H1xnrQ37A8yUp4S2ys47R8f/wSCSrmMaY1u7n6CxVYCpR9fajwy0/356UgwwhVKw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    resolution: {integrity: sha512-kNiC/1fKuXnoSxp8yEsloDw4Ot/mIcNoYYGLl2CipSIpBtSuiBH5nb6eBcxnRZdKOwf5dKZtZ7MVPL9qJocNJw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    resolution: {integrity: sha512-XDkvkBG/frS+xiZkJdY4KqOaoAwyxPdi2MysDQgF8NmZdssi32SWch0r4LTqKWLLlCBg9/R55POeXL5UAjg2wQ==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    resolution: {integrity: sha512-DKnKJJSwsYtA7YT0EFGhFB5Eqoo42X0l0vZBv4lDuxngEXiiNjeLemXoKQVDzhcbILD7eyXNa5jWUc+2hpmkEg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    resolution: {integrity: sha512-SwIgTAVM9QhCFPyHwL+e1yQ6o3paV6q25klESkXw+r/KW9QPhOOyA6Yr8nfnur3uqMTLJHAKHTLUnkyi/Nh7Aw==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    resolution: {integrity: sha512-raKA6DshYSle0sAOHBV1OkSRFMN+Mkz8sFiMmS3k+m5nP6pP56E17CRRePBL5qmR6ZgSEvGOz/44QUiKNkK9Pg==}
-    engines: {node: '>= 10'}
 
   '@envio-dev/hypersync-client-darwin-arm64@0.6.5':
     resolution: {integrity: sha512-BjFmDFd+7QKuEkjlvwQjKy9b+ZWidkZHyKPjKSDg6u3KJe+fr+uY3rsW9TXNscUxJvl8YxJ2mZl0svOH7ukTyQ==}
@@ -1148,8 +1106,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-arm64@3.2.0:
-    resolution: {integrity: sha512-UkdZ7MqPh84qcJEygWHEDwWuie3sTpCXGJmQUw3duo2W0NNoq+yFQcoSCe8feDxBJ1Y+TN2UZb7EydIJ2c3a/A==}
+  envio-darwin-arm64@3.3.0-alpha.10:
+    resolution: {integrity: sha512-RMdgZKInGXzxtJZH2GWku20R9PDlmpS+7zlMK6XLsYn1/k394NTDCjQASl93nMs1wqfye3iGW4ruqdKQ+MAomA==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1158,8 +1116,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  envio-darwin-x64@3.2.0:
-    resolution: {integrity: sha512-htC7TvdNaLibIEqUfUcwvByQmL3d8cqpCpVlny/EKycef+No8/Kd5wSxH3IRzLXCdQ2w4VhJ6/x/+Mepu59Npw==}
+  envio-darwin-x64@3.3.0-alpha.10:
+    resolution: {integrity: sha512-3fvT7yJq6MLUnaEk406TfMSRZAVhivpi+GutTcnr6vBl8SSnd1o/hPbr+f8S6kBj9BDEq0KRjwY4Ydnoe8YE7A==}
     cpu: [x64]
     os: [darwin]
 
@@ -1168,14 +1126,14 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-arm64@3.2.0:
-    resolution: {integrity: sha512-xpEGYefS17B3NgbrHzOcv435kBpsEG2Uy+5lYL5diwpUYqxVJ3bgvoJ4CcABcKBjP/kiuPzrLxtzzf4k0pZGPA==}
+  envio-linux-arm64@3.3.0-alpha.10:
+    resolution: {integrity: sha512-enlkZFiGkFBboYIdp4TtkJESyuZk7uqNsLRqDFIE7dZ5wmT+6xdedGKkzNbDNeGfpt1NBTVvobd4Ih7a8OU7CA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.2.0:
-    resolution: {integrity: sha512-QkUGcgHl1w6ry7LId1dlGXsfr5ZzXm8U4Y2rXZgws8S04v1F7gVHR1lzquqt0Bw6a6Bi7dW83LLlTAZswr+glA==}
+  envio-linux-x64-musl@3.3.0-alpha.10:
+    resolution: {integrity: sha512-gdfVuf7dDNOTjpHxv+kx42WUCYgFOaF4930c7sub8rUAXEE5AYy1hnu2a3gZXkyFUwzg9yQ56anIGQeXPlBvtA==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1185,8 +1143,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  envio-linux-x64@3.2.0:
-    resolution: {integrity: sha512-QDJyZNwo/pdy2Z4Hdmv+OWV9zEVQ/k+4QzZerogV7ic+rNXs1Z8IWNYwAk1BcD3XaS+0LPedsEhd4NaJeaOV4A==}
+  envio-linux-x64@3.3.0-alpha.10:
+    resolution: {integrity: sha512-EaPJ85ylSBJASJ4Vn7J7HRj+YUtLjdNAu+NmqhtD4Y2oajB2UVneGVNa3oC5LbGsloR5hzRVQNDMSe2pXK92vg==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1195,8 +1153,8 @@ packages:
     resolution: {integrity: sha512-xyo0mJc/+lAP0Og36Mdbn1m5xHXJXYjZ5E8s4eJQwjS3FFsEi8Z7lQc6qCHZjYtdRdGoGK2RLBMdEh5t+TRvrA==}
     hasBin: true
 
-  envio@3.2.0:
-    resolution: {integrity: sha512-NhPK2fGHTjwzN9fpPurQyWf++iGz6GQGXqmR4IF7ALrP38lej1OT65j20yq8QlbwWYcVOQ/JDKWOktPuEr0R0g==}
+  envio@3.3.0-alpha.10:
+    resolution: {integrity: sha512-GEdQ3l/aWvM7PiNiW5cYytKQPbrP6DctH8rUoJku1cwMCljPZ54lz+x8HPQeyolaiFJUR8kTZBITJQo0Gqb+qg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -1622,8 +1580,8 @@ packages:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
 
-  ox@0.12.4:
-    resolution: {integrity: sha512-+P+C7QzuwPV8lu79dOwjBKfB2CbnbEXe/hfyyrff1drrO1nOOj3Hc87svHfcW1yneRr3WXaKr6nz11nq+/DF9Q==}
+  ox@0.14.29:
+    resolution: {integrity: sha512-M5j87Ec4V99MQdRct/g09eWXW60g6zhHTUs1lr4deUtrPDnezBdCJTgKd7pxqTpSZBFveV0ALi9jMMuT1qKyNg==}
     peerDependencies:
       typescript: '>=5.4.0'
     peerDependenciesMeta:
@@ -2108,8 +2066,8 @@ packages:
       typescript:
         optional: true
 
-  viem@2.46.2:
-    resolution: {integrity: sha512-w8Qv5Vyo7TfXcH3vgmxRa1NRvzJCDy2aSGSRsJn3503nC/qVbgEQ+n3aj/CkqWXbloudZh97h5o5aQrQSVGy0w==}
+  viem@2.54.0:
+    resolution: {integrity: sha512-DW6KW3m89+3MLozFNPuI9Nhz2hJw375hUo1bpbo3qXipBvjdjF26B/d3U5adVyLGKOfqK4XeA1wPDWQTFQ/ltA==}
     peerDependencies:
       typescript: '>=5.0.4'
     peerDependenciesMeta:
@@ -2263,6 +2221,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.5.0:
     resolution: {integrity: sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==}
     engines: {node: '>=10.0.0'}
@@ -2326,33 +2296,6 @@ snapshots:
   '@elastic/ecs-pino-format@1.4.0':
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
-
-  '@envio-dev/hyperfuel-client-darwin-arm64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-darwin-x64@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-arm64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-gnu@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-linux-x64-musl@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client-win32-x64-msvc@1.2.2':
-    optional: true
-
-  '@envio-dev/hyperfuel-client@1.2.2':
-    optionalDependencies:
-      '@envio-dev/hyperfuel-client-darwin-arm64': 1.2.2
-      '@envio-dev/hyperfuel-client-darwin-x64': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-arm64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-gnu': 1.2.2
-      '@envio-dev/hyperfuel-client-linux-x64-musl': 1.2.2
-      '@envio-dev/hyperfuel-client-win32-x64-msvc': 1.2.2
 
   '@envio-dev/hypersync-client-darwin-arm64@0.6.5':
     optional: true
@@ -3053,28 +2996,28 @@ snapshots:
   envio-darwin-arm64@2.24.0:
     optional: true
 
-  envio-darwin-arm64@3.2.0:
+  envio-darwin-arm64@3.3.0-alpha.10:
     optional: true
 
   envio-darwin-x64@2.24.0:
     optional: true
 
-  envio-darwin-x64@3.2.0:
+  envio-darwin-x64@3.3.0-alpha.10:
     optional: true
 
   envio-linux-arm64@2.24.0:
     optional: true
 
-  envio-linux-arm64@3.2.0:
+  envio-linux-arm64@3.3.0-alpha.10:
     optional: true
 
-  envio-linux-x64-musl@3.2.0:
+  envio-linux-x64-musl@3.3.0-alpha.10:
     optional: true
 
   envio-linux-x64@2.24.0:
     optional: true
 
-  envio-linux-x64@3.2.0:
+  envio-linux-x64@3.3.0-alpha.10:
     optional: true
 
   envio@2.24.0(typescript@5.2.2):
@@ -3098,11 +3041,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  envio@3.2.0(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3):
+  envio@3.3.0-alpha.10(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
-      '@envio-dev/hyperfuel-client': 1.2.2
       '@fuel-ts/crypto': 0.96.1
       '@fuel-ts/errors': 0.96.1
       '@fuel-ts/hasher': 0.96.1
@@ -3126,14 +3068,14 @@ snapshots:
       react: 19.2.5
       rescript-schema: 9.5.1
       tsx: 4.21.0
-      viem: 2.46.2(typescript@6.0.3)
+      viem: 2.54.0(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.2.0
-      envio-darwin-x64: 3.2.0
-      envio-linux-arm64: 3.2.0
-      envio-linux-x64: 3.2.0
-      envio-linux-x64-musl: 3.2.0
+      envio-darwin-arm64: 3.3.0-alpha.10
+      envio-darwin-x64: 3.3.0-alpha.10
+      envio-linux-arm64: 3.3.0-alpha.10
+      envio-linux-x64: 3.3.0-alpha.10
+      envio-linux-x64-musl: 3.3.0-alpha.10
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -3542,9 +3484,9 @@ snapshots:
     dependencies:
       ws: 8.17.1
 
-  isows@1.0.7(ws@8.18.3):
+  isows@1.0.7(ws@8.20.1):
     dependencies:
-      ws: 8.18.3
+      ws: 8.20.1
 
   joycon@3.1.1: {}
 
@@ -3622,7 +3564,7 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  ox@0.12.4(typescript@6.0.3):
+  ox@0.14.29(typescript@6.0.3):
     dependencies:
       '@adraffy/ens-normalize': 1.11.1
       '@noble/ciphers': 1.3.0
@@ -4200,16 +4142,16 @@ snapshots:
       - utf-8-validate
       - zod
 
-  viem@2.46.2(typescript@6.0.3):
+  viem@2.54.0(typescript@6.0.3):
     dependencies:
       '@noble/curves': 1.9.1
       '@noble/hashes': 1.8.0
       '@scure/bip32': 1.7.0
       '@scure/bip39': 1.6.0
       abitype: 1.2.3(typescript@6.0.3)
-      isows: 1.0.7(ws@8.18.3)
-      ox: 0.12.4(typescript@6.0.3)
-      ws: 8.18.3
+      isows: 1.0.7(ws@8.20.1)
+      ox: 0.14.29(typescript@6.0.3)
+      ws: 8.20.1
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -4306,6 +4248,8 @@ snapshots:
   ws@8.17.1: {}
 
   ws@8.18.3: {}
+
+  ws@8.20.1: {}
 
   ws@8.5.0: {}
 


### PR DESCRIPTION
## Summary
This pull request updates the `envio` dependency from version 3.2.0 to 3.3.0-alpha.10.

## Changes
- Updated `envio` dependency to `3.3.0-alpha.10` in package.json

## Notes
This is an alpha release of envio. Please verify that all functionality works as expected with this pre-release version before merging to production branches.

https://claude.ai/code/session_01BY9QoEEsMtB1UG881jwgsM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Envio dependency to version 3.3.0-alpha.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->