### PR TITLE
fix: RPC URLs for MegaETH (4326) and Robinhood (4663) token metadata

### DIFF
--- a/src/utils/tokenMetadata.ts
+++ b/src/utils/tokenMetadata.ts
@@ -86,6 +86,13 @@ const getRpcUrl = (chainId: number): string => {
       return process.env.ENVIO_LINEA_RPC_URL || "https://linea.drpc.org";
     case 42220:
       return process.env.ENVIO_CELO_RPC_URL || "https://celo.drpc.org";
+    case 4326:
+      return process.env.ENVIO_MEGAETH_RPC_URL || "https://megaeth.drpc.org";
+    case 4663:
+      return (
+        process.env.ENVIO_ROBINHOOD_RPC_URL ||
+        "https://rpc.mainnet.chain.robinhood.com"
+      );
     // Add generic fallback for any chain
     default:
       throw new Error(`No RPC URL configured for chainId ${chainId}`);


### PR DESCRIPTION
getRpcUrl throws on unknown chainIds, so without these cases the first token-metadata fetch on either new chain would crash the indexer. Fallbacks verified: megaeth.drpc.org and the official Robinhood RPC (drpc's robinhood slug needs a key; there is no public drpc endpoint).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RPC connectivity support for the MegaETH network.
  * Added RPC connectivity support for the Robinhood network.
  * Existing network RPC behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->