### PR TITLE
Bump envio to 3.7.0, fix wrong-order indexes, and align indexes with v4.xyz queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
     "vitest": "4.1.0"
   },
   "dependencies": {
-    "envio": "3.6.1"
+    "envio": "3.7.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 3.6.1
-        version: 3.6.1(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3)
+        specifier: 3.7.0
+        version: 3.7.0(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3)
     devDependencies:
       '@types/node':
         specifier: 24.12.2
@@ -1105,8 +1105,8 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-arm64@3.6.1:
-    resolution: {integrity: sha512-ecGuGkptoCbfH5ULq4yAhRRB8pAK8pzQp6JahmBsH7dYSOmgM8xQRqgS5QwVgjrfQWl5GH3S4dyZpnSsCNcy+w==}
+  envio-darwin-arm64@3.7.0:
+    resolution: {integrity: sha512-OJnjb3KlMAidiDMW9r79suumOJGaO+zgE2A234Ad9vVlxC8ZdrY2Sy9D4HWJwu/nGsGzlWW2AsErw6PYtZv7Dw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -1115,8 +1115,8 @@ packages:
     cpu: [x64]
     os: [darwin]
 
-  envio-darwin-x64@3.6.1:
-    resolution: {integrity: sha512-zADvYOhv8Yjsp4a5AooJg4kRPKcidyjljru8XpUIIvLq5VdHQcs/5r1EnhDwPgA2Y9gBqTNCWZJ80pQs6Vg/0g==}
+  envio-darwin-x64@3.7.0:
+    resolution: {integrity: sha512-eFtydPwAyt/RqKpqVzQLvplgp2e6Vl3yc5K8EaOaZsciLIwtQPxWWCIO166FqL+TDeeuSXnGa6xZ9pst6gUoxA==}
     cpu: [x64]
     os: [darwin]
 
@@ -1125,14 +1125,14 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-arm64@3.6.1:
-    resolution: {integrity: sha512-dTbMq6BtAn0tEduGHdunyomIVNVTx32pr7tzRDdJ/rlPQxdNDkKboPIFeuxMoTiLKtUIyrkDRb/KZUNna72suQ==}
+  envio-linux-arm64@3.7.0:
+    resolution: {integrity: sha512-WA9vuJpL3jADd1E3vNlISiOscTwGnanvis83ipfsr1cG55B43//oVevI6X3KoKO6+uCfbcekP1N1NwtxcEDVuw==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  envio-linux-x64-musl@3.6.1:
-    resolution: {integrity: sha512-APwQYvKhzMEsrWsKAhjx2+p8kqJi00Oz46YyW7Ln005pt96Am6ACqC7pWoo5J5Zuui8Y2lR4wJmEWKZeH9pkRQ==}
+  envio-linux-x64-musl@3.7.0:
+    resolution: {integrity: sha512-G0SYEd7ELrqHPHnZ5w2bgEAa/A3t0TGUMbtyElYdk5B4WdBYpBEarMLsGQLOUlSkuLaPnDfr/V5nuA0D+vSdFw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -1142,8 +1142,8 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  envio-linux-x64@3.6.1:
-    resolution: {integrity: sha512-eynhAQXaEimq/QT0REEXPqjAs3J7rURymL7PRSXBvrfQVUUKjiO4l5S9jL5jlSpWpZR4o2xcW6xZAuk7O1B9sw==}
+  envio-linux-x64@3.7.0:
+    resolution: {integrity: sha512-QgpikP6CZNH1UVyKluF+0tPtHQ9f8nBc8oWkwB4rM2hMmDOTrUsHvw05Lhd8kIrdZv1ez5HvLbmMVWWNWMjQmQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -1152,8 +1152,8 @@ packages:
     resolution: {integrity: sha512-xyo0mJc/+lAP0Og36Mdbn1m5xHXJXYjZ5E8s4eJQwjS3FFsEi8Z7lQc6qCHZjYtdRdGoGK2RLBMdEh5t+TRvrA==}
     hasBin: true
 
-  envio@3.6.1:
-    resolution: {integrity: sha512-n8N3ih7rEL6saDTXPOI1sxwruaD4HfJBtNnrlrmDDzv9Ccj8IFElBQJc+JvSIfT8TwzVZynPiHiL6e/gvtc7fg==}
+  envio@3.7.0:
+    resolution: {integrity: sha512-lX4IYX8/2fqSJ1fnWWS2e93asxeQkZr6VqVKdUqUdrKMyEcesmnhIT48/H+JP2g16ecTGql0ralzdDcApERCHg==}
     engines: {node: '>=22.0.0'}
     hasBin: true
 
@@ -2979,28 +2979,28 @@ snapshots:
   envio-darwin-arm64@2.24.0:
     optional: true
 
-  envio-darwin-arm64@3.6.1:
+  envio-darwin-arm64@3.7.0:
     optional: true
 
   envio-darwin-x64@2.24.0:
     optional: true
 
-  envio-darwin-x64@3.6.1:
+  envio-darwin-x64@3.7.0:
     optional: true
 
   envio-linux-arm64@2.24.0:
     optional: true
 
-  envio-linux-arm64@3.6.1:
+  envio-linux-arm64@3.7.0:
     optional: true
 
-  envio-linux-x64-musl@3.6.1:
+  envio-linux-x64-musl@3.7.0:
     optional: true
 
   envio-linux-x64@2.24.0:
     optional: true
 
-  envio-linux-x64@3.6.1:
+  envio-linux-x64@3.7.0:
     optional: true
 
   envio@2.24.0(typescript@5.2.2):
@@ -3024,7 +3024,7 @@ snapshots:
       - utf-8-validate
       - zod
 
-  envio@3.6.1(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3):
+  envio@3.7.0(react-dom@19.1.0(react@19.2.5))(typescript@6.0.3):
     dependencies:
       '@clickhouse/client': 1.17.0
       '@elastic/ecs-pino-format': 1.4.0
@@ -3053,11 +3053,11 @@ snapshots:
       viem: 2.54.0(typescript@6.0.3)
       yargs: 17.7.2
     optionalDependencies:
-      envio-darwin-arm64: 3.6.1
-      envio-darwin-x64: 3.6.1
-      envio-linux-arm64: 3.6.1
-      envio-linux-x64: 3.6.1
-      envio-linux-x64-musl: 3.6.1
+      envio-darwin-arm64: 3.7.0
+      envio-darwin-x64: 3.7.0
+      envio-linux-arm64: 3.7.0
+      envio-linux-x64: 3.7.0
+      envio-linux-x64-musl: 3.7.0
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,7 +1,7 @@
 type Swap
   @storage(postgres: true, clickhouse: true)
-  @index(fields: ["timestamp", "pool"])
-  @index(fields: ["amountUSD", "pool"]) {
+  @index(fields: ["pool", ["timestamp", "DESC"]])
+  @index(fields: ["pool", ["amountUSD", "DESC"]]) {
   id: ID!
   chainId: BigInt!
   transaction: String! # Instead of Transaction reference
@@ -184,8 +184,8 @@ type Unsubscribe @storage(postgres: true, clickhouse: true) {
 
 type ModifyLiquidity
   @storage(postgres: true, clickhouse: true)
-  @index(fields: ["timestamp", "pool"])
-  @index(fields: ["amountUSD", "pool"]) {
+  @index(fields: ["pool", ["timestamp", "DESC"]])
+  @index(fields: ["pool", ["amountUSD", "DESC"]]) {
   id: ID!
   chainId: BigInt!
   transaction: String! # Instead of Transaction reference

--- a/schema.graphql
+++ b/schema.graphql
@@ -1,7 +1,6 @@
 type Swap
   @storage(postgres: true, clickhouse: true)
-  @index(fields: ["pool", ["timestamp", "DESC"]])
-  @index(fields: ["pool", ["amountUSD", "DESC"]]) {
+  @index(fields: ["pool", ["timestamp", "DESC"]]) {
   id: ID!
   chainId: BigInt!
   transaction: String! # Instead of Transaction reference
@@ -43,11 +42,14 @@ type PoolManager @storage(postgres: true, clickhouse: true) {
   hookedSwaps: BigInt! # number of swaps through hooked pools
 }
 
-type Pool @storage(postgres: true, clickhouse: true) {
+type Pool
+  @storage(postgres: true, clickhouse: true)
+  @index(fields: ["chainId", ["totalValueLockedUSD", "DESC"]])
+  @index(fields: ["hooks", "chainId", ["totalValueLockedUSD", "DESC"]]) {
   id: ID!
   chainId: BigInt!
   name: String!
-  createdAtTimestamp: BigInt!
+  createdAtTimestamp: BigInt! @index
   createdAtBlockNumber: BigInt!
   token0: String! # Instead of Token reference
   token1: String! # Instead of Token reference
@@ -95,7 +97,7 @@ type Tick @storage(postgres: true, clickhouse: true) {
 
 type Token @storage(postgres: true, clickhouse: true) {
   id: ID!
-  chainId: BigInt!
+  chainId: BigInt! @index
   symbol: String!
   name: String!
   decimals: BigInt!
@@ -126,7 +128,7 @@ type HookStats @storage(postgres: true, clickhouse: true) {
   numberOfPools: BigInt!
   numberOfSwaps: BigInt!
   firstPoolCreatedAt: BigInt!
-  totalValueLockedUSD: BigDecimal! # Total TVL across all pools using this hook
+  totalValueLockedUSD: BigDecimal! @index # Total TVL across all pools using this hook
   totalVolumeUSD: BigDecimal! # Total volume across all pools using this hook
   untrackedVolumeUSD: BigDecimal! # Untracked volume for non-whitelisted tokens
   totalFeesUSD: BigDecimal! # Total fees across all pools using this hook
@@ -184,8 +186,7 @@ type Unsubscribe @storage(postgres: true, clickhouse: true) {
 
 type ModifyLiquidity
   @storage(postgres: true, clickhouse: true)
-  @index(fields: ["pool", ["timestamp", "DESC"]])
-  @index(fields: ["pool", ["amountUSD", "DESC"]]) {
+  @index(fields: ["pool", ["timestamp", "DESC"]]) {
   id: ID!
   chainId: BigInt!
   transaction: String! # Instead of Transaction reference

--- a/schema.graphql
+++ b/schema.graphql
@@ -82,11 +82,13 @@ type Pool
   ticks: [Tick!]! @derivedFrom(field: "pool")
 }
 
-type Tick @storage(postgres: true, clickhouse: true) {
+type Tick
+  @storage(postgres: true, clickhouse: true)
+  @index(fields: ["pool", "tickIdx"]) {
   id: ID! # <pool address>#<tickIdx>
   chainId: BigInt!
   pool: Pool! # Pointer back to Pool
-  tickIdx: BigInt! @index
+  tickIdx: BigInt!
   liquidityGross: BigInt! # abs liquidity at this boundary
   liquidityNet: BigInt! # delta when price crosses boundary
   price0: BigDecimal! # Optional – 1.0001^tickIdx
@@ -186,7 +188,8 @@ type Unsubscribe @storage(postgres: true, clickhouse: true) {
 
 type ModifyLiquidity
   @storage(postgres: true, clickhouse: true)
-  @index(fields: ["pool", ["timestamp", "DESC"]]) {
+  @index(fields: ["pool", ["timestamp", "DESC"]])
+  @index(fields: ["pool", "transaction"]) {
   id: ID!
   chainId: BigInt!
   transaction: String! # Instead of Transaction reference


### PR DESCRIPTION
Prep for a new hosted-service deployment. Three parts: the version bump, the index-order fix from the August outage, and an audit that turned up indexes which exist only as hand-built DDL on live databases.

## 1. envio 3.6.1 → 3.7.0

| Check | Result |
|---|---|
| `envio codegen` | pass |
| `tsc` build | pass |
| `vitest` | 26/26 pass |
| `envio dev` (live run) | 613k Swaps, 65k ModifyLiquidity, 11k Pools across all 18 chains, zero errors |

3.7.0 adds per-handler `fields` selection and more RPC-source fields. `field_selection` in `config.yaml` is unchanged and still supported, so no config or handler changes were needed.

## 2. The outage fix: two indexes had their columns backwards

Nothing was *missing*, and it isn't `config.yaml` — envio has no index option there. The indexes existed with their **columns in the wrong order**.

Per the [2026-08-18 incident](https://github.com/enviodev/envio-wiki/blob/main/wiki/incidents/2026-08-hypertier-us-hasura-connection-exhaustion.md): `recentSwapsByPool` and `poolModifyLiquidity` filter on `pool` and sort by `timestamp DESC`, so they need an index leading with `pool`. Both declared `(timestamp, pool)`. Only the leading column narrows a B-tree scan range, so each call walked backwards through an 88 GB / 134 GB index testing `pool` on every entry — 20+ minutes per query. With `statement_timeout = 0` and a pooler sized to exactly `max_connections`, ~540 requests over four minutes took all 200 connection slots.

The trap: this looks healthy in `EXPLAIN`. A trailing-column qual still renders as `Index Cond` with a cheap estimate. You have to read the column order.

```graphql
# before                              # after
@index(fields: ["timestamp", "pool"])  @index(fields: ["pool", ["timestamp", "DESC"]])
```

Three operations the incident didn't name share the shape and are fixed by the same change: `arbitrageSwaps`, `recentSwapsMultiplePools`, and `rwaSwaps`.

## 3. Indexes that existed only as hand-built DDL ⚠️

The most consequential finding. Both were applied directly to live databases with `CREATE INDEX CONCURRENTLY` and **never added to `schema.graphql`**, so a fresh deployment silently comes up without them.

| Index | Why it exists |
|---|---|
| `ModifyLiquidity (pool, transaction)` | Built 2025-10-28 after Binance reported slow queries on `where: {pool_id: {_eq}, transaction: {_eq}}`. Took ~2.5 h concurrently against 373 M rows then; the table is ~830 M now |
| `Tick (pool, tickIdx)` | Serves `ticksByPoolRange`, used by v4.xyz and the EthCC liquidity viz. Production went through a hand-built `Tick_pool` first, then this composite |

Declaring them means the next deployment builds them during backfill instead of someone rediscovering the need and running a multi-hour `CONCURRENTLY` against a live table.

There is no wiki page tracking out-of-band index changes, and nothing in this repo recorded either one — worth fixing separately.

## 4. Audit of every v4.xyz query

Read every GraphQL operation in `moose-code/uniswap-v4-analytics` at `origin/main` against the declared indexes.

**Added** — each matches a query with nothing to serve it:

| Index | Query |
|---|---|
| `Pool (chainId, totalValueLockedUSD DESC)` | `poolsByChain`; also narrows `rwaPools` before its `volumeUSD` sort |
| `Pool (hooks, chainId, totalValueLockedUSD DESC)` | `poolsByHook` — runs with **no LIMIT** |
| `Pool.createdAtTimestamp` | `recentPools` (the Pulse "Recent Pools" column) |
| `HookStats.totalValueLockedUSD` | `stats`, limit 1000 |
| `Token.chainId` | `rwaUniverse`; its other qual is an unindexable ILIKE, so this is what stops a full `Token` scan |

**Dropped as unused**, on the two largest tables:

- `Swap (pool, amountUSD DESC)` and `ModifyLiquidity (pool, amountUSD DESC)` — nothing filters on `pool` and sorts by `amountUSD`. The `largest*` queries sort by `amountUSD` with no pool filter and are served by ModifyLiquidity's standalone `amountUSD` index. At 637 M / 830 M rows these were ~88 GB and ~134 GB earning nothing, on a volume already 84% full.
- `Tick.tickIdx` standalone — the new `(pool, tickIdx)` composite covers every query that filters by pool first, and a `tickIdx` qual without a pool isn't a meaningful access pattern.

**Kept deliberately**: `Pool.volumeUSD` (used by `rwaPools` — nearly dropped this one), and the `tokenId`/`owner`/`timestamp` indexes on `Position`, `Transfer`, `Subscribe`, `Unsubscribe`. Unused by v4.xyz, but small tables and the endpoint has consumers beyond that frontend.

## Still broken after this PR: `search`

```graphql
pools: Pool(where: {_or: [{name: {_ilike: $pattern}}, {id: {_ilike: $pattern}}]}, order_by: {txCount: desc})
hooks: HookStats(where: {id: {_ilike: $pattern}}, order_by: {numberOfSwaps: desc})
```

with `pattern = %q%`. A leading-wildcard `ILIKE` cannot use a B-tree index, and `@index` only ever emits B-tree, so this is not expressible in `schema.graphql`. Needs a `pg_trgm` GIN index out of band, or search moved off Postgres. It fires per keystroke and was one of the three operations that appeared during the August incident.

## Verification

Driving envio's own `IndexDefinition.makeCreateQuery` reproduces the intended DDL with column order preserved and `DESC` emitted, e.g.:

```sql
CREATE INDEX ... ON "Swap"("pool", "timestamp" DESC);
CREATE INDEX ... ON "ModifyLiquidity"("pool", "transaction");
CREATE INDEX ... ON "Pool"("hooks", "chainId", "totalValueLockedUSD" DESC);
```

Caveat: that exercises the DDL generator with hand-built inputs; the parser side is covered by `envio codegen` accepting the schema. Entity-reference fields map to `_id` columns in the real path, so `pool` becomes `pool_id` — matching the existing `ModifyLiquidity_timestamp_pool_id` naming. I could not observe these on a live database because `@index` indexes are only built when backfill finishes, which isn't reachable locally across 18 chains.

## Notes for the deploy

- Indexes build at the end of backfill, so a fresh deployment picks up the whole set automatically. They use plain `CREATE INDEX` (not `CONCURRENTLY`), which takes a SHARE lock blocking writes but not reads.
- The incident's two **platform** action items — a real `statement_timeout`, and a pooler capped below `max_connections` — remain open and are not addressed here.
- The v4.xyz endpoint was deliberately left at `0/0` replicas and needs scaling back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved query performance for pools by adding TVL and timestamp indexes.
  - Added faster lookups for ticks, tokens, hook statistics, and liquidity activity.
  - Improved filtering of liquidity changes by pool and transaction.
  - Optimized swap and liquidity queries by removing less efficient amount-based indexes.

- **Maintenance**
  - Updated the underlying indexing component to a newer version for improved reliability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->