### PR TITLE
Per-chain entities: isolated multichain rollbacks

### DIFF
--- a/.envio/cache/linkToLatestCache.txt
+++ b/.envio/cache/linkToLatestCache.txt
@@ -1,7 +1,40 @@
-Due to GitHub file size limitations, the latest cache file is temporarily hosted on Google Drive.
+Due to GitHub file size limitations, the token metadata cache is hosted on Google Drive:
+https://drive.google.com/drive/folders/1PNodRythHPOwbIEr9k5jPwx4gg1TTwKH?usp=sharing
 
-Cache last updated: 29/10/2025
+Cache data last updated: 22/07/2026
+Cache format changed:    07/09/2026  <-- see below, the layout is different now
+
+
+THE FORMAT HAS CHANGED — one file per chain
+
+This indexer now sets `disable_default_cross_chain: true` in config.yaml, which
+makes effect caches per-chain. A single flat getTokenMetadata.tsv is read as a
+cross-chain cache and is NO LONGER USED. Leaving it in place silently refetches
+every token's metadata over RPC instead of erroring, so the layout matters.
+
+Old (no longer used):        New:
+  .envio/cache/                .envio/cache/
+    getTokenMetadata.tsv         1/getTokenMetadata.tsv
+                                 10/getTokenMetadata.tsv
+                                 8453/getTokenMetadata.tsv
+                                 ... one directory per chain id, 18 total
 
 To update your local cache:
-1. Download the latest cache file from: https://drive.google.com/drive/folders/1PNodRythHPOwbIEr9k5jPwx4gg1TTwKH?usp=sharing
-2. Replace your current cache file with the downloaded version
+1. Download getTokenMetadata-per-chain-<date>.zip from the Drive folder above.
+2. Delete any flat .envio/cache/getTokenMetadata.tsv you still have.
+3. Unzip into .envio/cache/ so the chain-id directories sit directly inside it.
+
+The cache keys are unchanged between the two layouts — both are
+["0xADDRESS",CHAIN_ID] — so the per-chain files are a pure split of the old flat
+file. Nothing needs re-keying, and the archive is a straight repartition of the
+22/07/2026 data: 15,145,083 rows in, 15,145,083 rows out.
+
+
+Note on "unknown" / "UNKNOWN" entries
+
+About 14.8k rows read {"name": "unknown", "symbol": "UNKNOWN", "decimals": 18},
+almost all on Base. These are NOT the cached RPC failures fixed in PR #50 — they
+are tokens whose on-chain name and symbol are literally a single space, which
+sanitizeString trims to "" before the fallback substitutes "unknown". Verified
+by re-querying 50 of them live: all 50 still return " " for both fields. Purging
+them just re-fetches the same values, so leave them alone.

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,6 @@
 # yaml-language-server: $schema=./node_modules/envio/evm.schema.json
 name: uniswap-v4-indexer
+disable_default_cross_chain: true
 storage:
   postgres: true
   clickhouse: true

--- a/schema.graphql
+++ b/schema.graphql
@@ -2,7 +2,6 @@ type Swap
   @storage(postgres: true, clickhouse: true)
   @index(fields: ["pool", ["timestamp", "DESC"]]) {
   id: ID!
-  chainId: BigInt!
   transaction: String! # Instead of Transaction reference
   timestamp: BigInt! @index
   pool: String! # Instead of Pool reference
@@ -24,7 +23,6 @@ type Swap
 
 type PoolManager @storage(postgres: true, clickhouse: true) {
   id: ID!
-  chainId: BigInt!
   poolCount: BigInt!
   txCount: BigInt!
   totalVolumeUSD: BigDecimal!
@@ -44,10 +42,8 @@ type PoolManager @storage(postgres: true, clickhouse: true) {
 
 type Pool
   @storage(postgres: true, clickhouse: true)
-  @index(fields: ["chainId", ["totalValueLockedUSD", "DESC"]])
-  @index(fields: ["hooks", "chainId", ["totalValueLockedUSD", "DESC"]]) {
+  @index(fields: ["hooks", ["totalValueLockedUSD", "DESC"]]) {
   id: ID!
-  chainId: BigInt!
   name: String!
   createdAtTimestamp: BigInt! @index
   createdAtBlockNumber: BigInt!
@@ -86,7 +82,6 @@ type Tick
   @storage(postgres: true, clickhouse: true)
   @index(fields: ["pool", "tickIdx"]) {
   id: ID! # <pool address>#<tickIdx>
-  chainId: BigInt!
   pool: Pool! # Pointer back to Pool
   tickIdx: BigInt!
   liquidityGross: BigInt! # abs liquidity at this boundary
@@ -99,7 +94,6 @@ type Tick
 
 type Token @storage(postgres: true, clickhouse: true) {
   id: ID!
-  chainId: BigInt! @index
   symbol: String!
   name: String!
   decimals: BigInt!
@@ -126,7 +120,6 @@ type Bundle @storage(postgres: true, clickhouse: true) {
 
 type HookStats @storage(postgres: true, clickhouse: true) {
   id: ID! # hook address
-  chainId: BigInt!
   numberOfPools: BigInt!
   numberOfSwaps: BigInt!
   firstPoolCreatedAt: BigInt!
@@ -138,7 +131,6 @@ type HookStats @storage(postgres: true, clickhouse: true) {
 
 type Position @storage(postgres: true, clickhouse: true) {
   id: ID! # <chainId>_<tokenId>
-  chainId: BigInt!
   tokenId: BigInt! @index
   owner: String! @index # address of current owner
   origin: String! # the EOA that minted the position
@@ -151,7 +143,6 @@ type Position @storage(postgres: true, clickhouse: true) {
 
 type Transfer @storage(postgres: true, clickhouse: true) {
   id: ID!
-  chainId: BigInt!
   tokenId: BigInt! @index
   from: String! # address of previous owner
   to: String! # address of new owner
@@ -164,7 +155,6 @@ type Transfer @storage(postgres: true, clickhouse: true) {
 
 type Subscribe @storage(postgres: true, clickhouse: true) {
   id: ID!
-  chainId: BigInt!
   tokenId: BigInt! @index
   address: String! # address of subscriber
   transaction: String! # Instead of Transaction reference
@@ -176,7 +166,6 @@ type Subscribe @storage(postgres: true, clickhouse: true) {
 
 type Unsubscribe @storage(postgres: true, clickhouse: true) {
   id: ID!
-  chainId: BigInt!
   tokenId: BigInt! @index
   address: String! # address of unsubscriber
   transaction: String! # Instead of Transaction reference
@@ -191,7 +180,6 @@ type ModifyLiquidity
   @index(fields: ["pool", ["timestamp", "DESC"]])
   @index(fields: ["pool", "transaction"]) {
   id: ID!
-  chainId: BigInt!
   transaction: String! # Instead of Transaction reference
   timestamp: BigInt! @index
   pool: Pool! # Instead of Pool reference

--- a/src/handlers/initialize-handler.ts
+++ b/src/handlers/initialize-handler.ts
@@ -28,7 +28,6 @@ indexer.onEvent({ contract: "PoolManager", event: "Initialize" }, async ({ event
   if (!poolManager) {
     poolManager = {
       id: `${event.chainId}_${event.srcAddress}`,
-      chainId: BigInt(event.chainId),
       poolCount: 1n,
       txCount: 0n,
       totalVolumeUSD: new BigDecimal(0),
@@ -69,7 +68,6 @@ indexer.onEvent({ contract: "PoolManager", event: "Initialize" }, async ({ event
     if (!hookStats) {
       hookStats = {
         id: hookStatsId,
-        chainId: BigInt(event.chainId),
         numberOfPools: 0n,
         numberOfSwaps: 0n,
         firstPoolCreatedAt: BigInt(event.block.timestamp),
@@ -98,7 +96,6 @@ indexer.onEvent({ contract: "PoolManager", event: "Initialize" }, async ({ event
     });
     token0 = {
       id: token0Id,
-      chainId: BigInt(event.chainId),
       symbol: metadata.symbol,
       name: metadata.name,
       decimals: BigInt(metadata.decimals),
@@ -132,7 +129,6 @@ indexer.onEvent({ contract: "PoolManager", event: "Initialize" }, async ({ event
     });
     token1 = {
       id: token1Id,
-      chainId: BigInt(event.chainId),
       symbol: metadata.symbol,
       name: metadata.name,
       decimals: BigInt(metadata.decimals),
@@ -226,7 +222,6 @@ indexer.onEvent({ contract: "PoolManager", event: "Initialize" }, async ({ event
   // Create new pool with prices
   context.Pool.set({
     id: `${event.chainId}_${event.params.id}`,
-    chainId: BigInt(event.chainId),
     name: poolName,
     createdAtTimestamp: BigInt(event.block.timestamp),
     createdAtBlockNumber: BigInt(event.block.number),

--- a/src/handlers/modifyLiquidity-handler.ts
+++ b/src/handlers/modifyLiquidity-handler.ts
@@ -71,7 +71,6 @@ indexer.onEvent({ contract: "PoolManager", event: "ModifyLiquidity" }, async ({ 
       lowerTickId,
       lowerTickIdx,
       poolId,
-      BigInt(event.chainId),
       BigInt(event.block.timestamp),
       BigInt(event.block.number)
     );
@@ -81,7 +80,6 @@ indexer.onEvent({ contract: "PoolManager", event: "ModifyLiquidity" }, async ({ 
       upperTickId,
       upperTickIdx,
       poolId,
-      BigInt(event.chainId),
       BigInt(event.block.timestamp),
       BigInt(event.block.number)
     );
@@ -208,7 +206,6 @@ indexer.onEvent({ contract: "PoolManager", event: "ModifyLiquidity" }, async ({ 
   const modifyLiquidityId = `${event.chainId}_${event.transaction.hash}_${event.logIndex}`;
   const modifyLiquidity = {
     id: modifyLiquidityId,
-    chainId: BigInt(event.chainId),
     transaction: event.transaction.hash,
     timestamp: BigInt(event.block.timestamp),
     pool_id: pool.id,

--- a/src/handlers/positionManager-handler.ts
+++ b/src/handlers/positionManager-handler.ts
@@ -26,7 +26,6 @@ indexer.onEvent(
     // change ownership
     const position = (await context.Position.get(id)) ?? {
       id,
-      chainId: BigInt(event.chainId),
       tokenId: event.params.id,
       owner: event.params.to,
       origin: event.transaction.from || "NONE",
@@ -37,7 +36,6 @@ indexer.onEvent(
 
     context.Transfer.set({
       id: eventId(event),
-      chainId: BigInt(event.chainId),
       tokenId: event.params.id,
       from: event.params.from,
       to: event.params.to,
@@ -55,7 +53,6 @@ indexer.onEvent(
   async ({ event, context }) => {
     context.Subscribe.set({
       id: eventId(event),
-      chainId: BigInt(event.chainId),
       tokenId: event.params.tokenId,
       address: event.params.subscriber,
       transaction: event.transaction.hash,
@@ -72,7 +69,6 @@ indexer.onEvent(
   async ({ event, context }) => {
     context.Unsubscribe.set({
       id: eventId(event),
-      chainId: BigInt(event.chainId),
       tokenId: event.params.tokenId,
       address: event.params.subscriber,
       transaction: event.transaction.hash,

--- a/src/handlers/swap-handler.ts
+++ b/src/handlers/swap-handler.ts
@@ -249,7 +249,6 @@ indexer.onEvent({ contract: "PoolManager", event: "Swap" }, async ({ event, cont
 
   let entity: Swap = {
     id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
-    chainId: BigInt(event.chainId),
     transaction: event.transaction.hash,
     timestamp: BigInt(event.block.timestamp),
     pool: `${event.chainId}_${event.params.id}`,

--- a/src/indexer.test.ts
+++ b/src/indexer.test.ts
@@ -27,7 +27,6 @@ describe("Uniswap V4 Indexer", () => {
             "Position": {
               "sets": [
                 {
-                  "chainId": 1n,
                   "createdAtTimestamp": 1768478831n,
                   "id": "1_133850",
                   "origin": "0x16a4eC779ec71F9019fF79CbdD082a078C9eA06A",
@@ -39,7 +38,6 @@ describe("Uniswap V4 Indexer", () => {
             "Transfer": {
               "sets": [
                 {
-                  "chainId": 1n,
                   "from": "0x0000000000000000000000000000000000000000",
                   "id": "1_24240005_344",
                   "logIndex": 344n,

--- a/src/utils/tick.ts
+++ b/src/utils/tick.ts
@@ -6,13 +6,11 @@ export function createInitialTick(
   tickId: string,
   tickIdx: number,
   poolId: string,
-  chainId: bigint,
   timestamp: bigint,
   blockNumber: bigint
 ) {
   const tick = {
     id: tickId,
-    chainId,
     pool_id: poolId,
     tickIdx: BigInt(tickIdx),
     poolAddress: poolId,


### PR DESCRIPTION
**Stacked on #62** (isolated rollbacks need envio 3.10.0). Base is `chore/bump-envio-3.10.0`; retarget to `main` once that merges.

Sets `disable_default_cross_chain: true`. Entity rows, entity history and reorg rollback become per-chain instead of shared across all 18 chains, and per-chain entities are split into Postgres LIST partitions on `chainId`.

## ⚠️ Breaking: `chainId` changes from `numeric` to `Int`

You said you'd handle the v4.xyz side — here is the exact change needed. Verified on a live run:

```
Pool.chainId = integer      (was numeric)
```

Four v4.xyz operations declare the old type and will fail on a variable type mismatch until updated:

| Operation | File |
|---|---|
| `poolsByChain` | `app/api/pools/route.ts` |
| `poolsByHook` | `app/api/pools-by-hook/route.ts` |
| `rwaUniverse` | `lib/rwaServer.ts` |
| `rwaPools` | `lib/rwaServer.ts` |

```diff
- query poolsByChain($chainId: numeric!)
+ query poolsByChain($chainId: Int!)
```

Consumers that only *select* `chainId` (Binance's `ModifyLiquidity` query) keep working, but the JSON value changes from a string to a number.

## ⚠️ The token metadata effect cache is invalidated

Worth planning for before deploy. Effects without an explicit `crossChain` option get one cache **per chain**, so the single shared cache is not reused. On the live run the indexer began building fresh per-chain tables:

```
envio_1_effect_getTokenMetadata     = 250
envio_130_effect_getTokenMetadata   =  43
envio_10_effect_getTokenMetadata    =  29
...
envio_effect_getTokenMetadata       = 15,145,083   ← the existing shared cache, unused
```

So a deployment refetches token metadata over RPC across all 18 chains rather than reusing 15.1 M cached rows. That matters because failed ERC-20 reads fall back to placeholder metadata — the local run already logged `All ERC-20 reads failed ... not caching fallback metadata` on Soneium — and a mass refetch is exactly when that happens at scale. Recommend warming or re-keying the cache first.

## No row identity changes

Every entity id here is **already** chain-namespaced, so nothing merges or splits — the change is purely additive to the physical layout:

| Entity | id |
|---|---|
| PoolManager | `${chainId}_${srcAddress}` |
| Bundle | `${chainId}` |
| Pool | `${chainId}_${params.id}` |
| HookStats | `${chainId}_${hooks}` |
| Token | `${chainId}_${currency}` |
| Swap | `${chainId}_${block}_${logIndex}` |
| ModifyLiquidity | `${chainId}_${txHash}_${logIndex}` |
| Position | `${chainId}_${tokenId}` |
| Transfer / Subscribe / Unsubscribe | `${chainId}_${block}_${logIndex}` |
| Tick | `${poolId}#${tickIdx}` — inherits it transitively |

## Code changes

Per-chain mode reserves the `chainId` column, so the explicit `chainId: BigInt!` field is removed from all 11 entities that declared it and envio supplies the column. Handlers stop setting it. `event.chainId` reads are untouched — including the `getTokenMetadata` effect input, which is an effect key, not an entity field.

## Index simplification

With LIST partitioning on `chainId`, the partition key is constant inside each partition's index, so a leading `chainId` earns nothing:

- `Pool (chainId, totalValueLockedUSD DESC)` — **removed**. Partition pruning plus the existing standalone `totalValueLockedUSD` index covers `poolsByChain`.
- `Pool (hooks, chainId, totalValueLockedUSD DESC)` → `Pool (hooks, totalValueLockedUSD DESC)`
- `Token.chainId @index` — removed; `chainId` is the partition key now.

## Verification

| Check | Result |
|---|---|
| `envio codegen` | pass |
| `tsc` build | pass |
| `vitest` | 26/26 pass (one inline snapshot updated — `chainId` correctly no longer in handler `sets`) |
| `envio dev` (live) | indexes across chains, **zero** errors |

Confirmed directly against the running database:

```
Pool_pkey -> PRIMARY KEY (id, "chainId")
Pool  -> LIST ("chainId")     Swap -> LIST ("chainId")   ...
partitions: Pool$130, Swap$130, Tick$130, Token$130, Bundle$1, Bundle$10, ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)